### PR TITLE
feat: add ghq and zoxide to aqua packages

### DIFF
--- a/dot_config/aquaproj-aqua/aqua-checksums.json
+++ b/dot_config/aquaproj-aqua/aqua-checksums.json
@@ -6,6 +6,26 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/ajeetdsouza/zoxide/v0.9.8/zoxide-0.9.8-aarch64-apple-darwin.tar.gz",
+      "checksum": "3D1EC4AF7F3D351629F500B432E6C735CAF3216AB3EAA76DBE8FFBC8F3006F5A",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/ajeetdsouza/zoxide/v0.9.8/zoxide-0.9.8-aarch64-unknown-linux-musl.tar.gz",
+      "checksum": "078CC9CC8CEDB6C45EDB84C0F5BAD53518C610859C73BDB3009A52B89652C103",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/ajeetdsouza/zoxide/v0.9.8/zoxide-0.9.8-x86_64-apple-darwin.tar.gz",
+      "checksum": "CFA865FFD1BA87DF2962F40EBD80C366F1D2B484F0C05B6DA6B0104F50822F86",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/ajeetdsouza/zoxide/v0.9.8/zoxide-0.9.8-x86_64-unknown-linux-musl.tar.gz",
+      "checksum": "4092EE38AA1EFDE42E4EFB2F9C872DF5388198AACAE7F1A74E5EB5C3CC7F531C",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/astral-sh/uv/0.8.0/uv-aarch64-apple-darwin.tar.gz",
       "checksum": "5A5CA58E3999D4F440632DA87A56F7030EAAA3A13D3896561EEC5FD51CB9AD45",
       "algorithm": "sha256"
@@ -284,6 +304,26 @@
       "id": "github_release/github.com/starship/starship/v1.23.0/starship-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "8D06D2CC67AEDD6316FF58AB679FB80CDED0D85DE1DCD5727DF0633D35356D57",
       "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/x-motemen/ghq/v1.8.0/ghq_darwin_amd64.zip",
+      "checksum": "F50A794201BAC18DF1AC8D00E863E9635576AA94",
+      "algorithm": "sha1"
+    },
+    {
+      "id": "github_release/github.com/x-motemen/ghq/v1.8.0/ghq_darwin_arm64.zip",
+      "checksum": "6FD6333348FDAF78DFBBE36CEC168F3E656A63C8",
+      "algorithm": "sha1"
+    },
+    {
+      "id": "github_release/github.com/x-motemen/ghq/v1.8.0/ghq_linux_amd64.zip",
+      "checksum": "F38219DDBC6EF6FEBD75556902EEE4759BAD07C3",
+      "algorithm": "sha1"
+    },
+    {
+      "id": "github_release/github.com/x-motemen/ghq/v1.8.0/ghq_linux_arm64.zip",
+      "checksum": "E5A73C5F4785D798A66B10419AB7B43B8525A7E4",
+      "algorithm": "sha1"
     },
     {
       "id": "http/awscli.amazonaws.com/AWSCLIV2-2.27.56.pkg",

--- a/dot_config/aquaproj-aqua/aqua.yaml
+++ b/dot_config/aquaproj-aqua/aqua.yaml
@@ -37,3 +37,5 @@ packages:
   - name: jqlang/jq@jq-1.8.1
   - name: mikefarah/yq@v4.46.1
   - name: jdx/mise@v2025.7.20
+  - name: x-motemen/ghq@v1.8.0
+  - name: ajeetdsouza/zoxide@v0.9.8


### PR DESCRIPTION
Add two new CLI tools for improved workflow:
- ghq v1.8.0: Remote repository management tool
- zoxide v0.9.8: Smarter cd command that learns your habits