### PR TITLE
fix: direnvのallow実行をcdコマンドの前に移動

### DIFF
--- a/dot_zsh/functions/git-worktree.zsh
+++ b/dot_zsh/functions/git-worktree.zsh
@@ -245,8 +245,12 @@ gwc() {
         fi
 
         echo "\nChanging to target directory and running setup..."
+        # 先に必要なファイルの存在を確認してallowを実行
+        if command -v direnv >/dev/null 2>&1 && [ -f "$target_dir/.envrc" ]; then
+            direnv allow "$target_dir"
+        fi
+        
         cd "$target_dir" && {
-            if command -v direnv >/dev/null 2>&1 && [ -f ".envrc" ]; then direnv allow .; fi
             if command -v aqua >/dev/null 2>&1 && [ -f "aqua.yaml" ]; then aqua policy allow; fi
             if command -v pnpm >/dev/null 2>&1 && [ -f "pnpm-lock.yaml" ]; then pnpm i; fi
         }


### PR DESCRIPTION
direnvのallowコマンドをcdコマンドの後ではなく前に実行するように修正。
これにより、ターゲットディレクトリへの移動前に.envrcファイルの存在確認と
allowの実行を行い、より確実な環境設定を実現。