### PR TITLE
fix: pnpmインストール条件をpackage.jsonの存在チェックに修正

### DIFF
--- a/dot_zsh/functions/git-worktree.zsh
+++ b/dot_zsh/functions/git-worktree.zsh
@@ -252,7 +252,7 @@ gwc() {
         
         cd "$target_dir" && {
             if command -v aqua >/dev/null 2>&1 && [ -f "aqua.yaml" ]; then aqua policy allow; fi
-            if command -v pnpm >/dev/null 2>&1 && [ -f "package.json" ]; then pnpm i; fi
+            if command -v pnpm >/dev/null 2>&1 && [ -f "package.json" ] && ! [ -f "package-lock.json" ] && ! [ -f "yarn.lock" ] && ! [ -f "bun.lockb" ]; then pnpm i; fi
         }
 
         # 最後に Cursor で開く（最初に選択していた場合）

--- a/dot_zsh/functions/git-worktree.zsh
+++ b/dot_zsh/functions/git-worktree.zsh
@@ -252,7 +252,7 @@ gwc() {
         
         cd "$target_dir" && {
             if command -v aqua >/dev/null 2>&1 && [ -f "aqua.yaml" ]; then aqua policy allow; fi
-            if command -v pnpm >/dev/null 2>&1 && [ -f "pnpm-lock.yaml" ]; then pnpm i; fi
+            if command -v pnpm >/dev/null 2>&1 && [ -f "package.json" ]; then pnpm i; fi
         }
 
         # 最後に Cursor で開く（最初に選択していた場合）


### PR DESCRIPTION
pnpm-lock.yamlではなくpackage.jsonの存在をチェックするように変更。
これにより、まだpnpm installが実行されていない新規プロジェクトでも
適切にpnpmのインストールが実行されるようになる。