### PR TITLE
feat: gwc関数で元のディレクトリに戻る機能を追加

### DIFF
--- a/dot_zsh/functions/git-worktree.zsh
+++ b/dot_zsh/functions/git-worktree.zsh
@@ -75,6 +75,9 @@ gwr() {
 #   export GWC_COPY_FILES=".env.test,config.local.json"  # 環境変数で事前設定
 #
 gwc() {
+    # 元のディレクトリを保存
+    local original_dir=$(pwd)
+    
     local default_copy_files=(".envrc.local" ".env.local" "settings.local.json" "CLAUDE.local.md" ".mcp.json")
     local extra_copy_files=()
 
@@ -259,6 +262,8 @@ gwc() {
         if $open_with_cursor; then
             echo "\nCursor で開いています..."
             cursor .
+            echo "元のディレクトリに戻ります: $original_dir"
+            cd "$original_dir"
         fi
         # ★★★ ここまで ★★★
     else


### PR DESCRIPTION
Cursorでworktreeを開いた後、自動的に元のディレクトリに戻るように修正。
これにより、gwc実行後もユーザーは元の作業ディレクトリで作業を継続できる。