### PR TITLE
fix: set PATH before cursor-agent installation check

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -246,8 +246,8 @@ alias cc=$HOME/.local/share/mise/installs/npm-anthropic-ai-claude-code/1.0.55/bi
 alias claude=$HOME/.local/share/mise/installs/npm-anthropic-ai-claude-code/1.0.55/bin/claude
 export CLAUDE_CODE_AUTO_UPDATE=false
 
+export PATH="$HOME/.local/bin:$PATH"
 # cursor-agentが無ければinstall
 if ! command -v cursor-agent &> /dev/null; then
   curl https://cursor.com/install -fsS | bash
 fi
-export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
PATH環境変数の設定をcursor-agentのインストールチェック前に移動。
これにより、cursor-agentが$HOME/.local/binにインストールされた直後から
コマンドが利用可能になる。