### PR TITLE
feat: direnvrcファイルを追加し、gitignoreを更新

### DIFF
--- a/dot_config/git/ignore
+++ b/dot_config/git/ignore
@@ -4,3 +4,6 @@ settings.local.json
 z/
 .envrc.local
 .DS_STORE
+.serena
+.lsmcp
+.envrc-aliases

--- a/dot_direnvrc
+++ b/dot_direnvrc
@@ -1,0 +1,27 @@
+# Clear existing aliases when entering a directory
+rm -rf "$PWD/.envrc-aliases"
+
+export_alias() {
+  # Create a new alias
+  local name=$1
+  shift
+
+  local alias_dir="$PWD/.envrc-aliases"
+  local alias_file="$alias_dir/$name"
+  local oldpath="$PATH"
+
+  # If this is the first time we're calling export_alias, add to PATH once
+  if ! [[ ":$PATH:" == *":$alias_dir:"* ]]; then
+    mkdir -p "$alias_dir"
+    PATH_add "$alias_dir"
+  fi
+
+  # Write the alias file
+  cat <<EOT >"$alias_file"
+#!/usr/bin/env bash
+set -e
+PATH="$oldpath"
+exec $@ \$@
+EOT
+  chmod +x "$alias_file"
+}


### PR DESCRIPTION
direnvでエイリアスを動的に作成・管理するための設定を追加。
export_alias関数により、プロジェクト固有のコマンドエイリアスを
.envrc-aliasesディレクトリに生成し、PATHに追加する仕組みを実装。

また、.gitignoreに以下を追加：
- .serena: Serena MCPサーバー関連ファイル
- .lsmcp: LSMCPツール関連ファイル
- .envrc-aliases: direnvで生成されるエイリアスディレクトリ