### PR TITLE
fix: ignore meta files in chezmoi

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -12,3 +12,6 @@ aqua-checksums.json
 .github
 renovate.json5
 .envrc
+AGENTS.md
+Taskfile.yaml
+create_dot_zsh


### PR DESCRIPTION
## Summary
- prevent chezmoi from syncing AGENTS.md and other project files

## Testing
- `chezmoi diff` *(missing: chezmoi)*
- `chezmoi --source . --dry-run --verbose apply` *(missing: chezmoi)*
- `cd dot_config/aquaproj-aqua && aqua install --test` *(missing: aqua)*

------
https://chatgpt.com/codex/tasks/task_e_68c74ef7f9048333b1b3f0da8a098203