### PR TITLE
feat: ccgate v0.4.0 に対応

### DIFF
--- a/dot_claude/ccgate.jsonnet
+++ b/dot_claude/ccgate.jsonnet
@@ -18,6 +18,7 @@
     'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate. deny_message: 現在のワークツリー外のチェックアウトにアクセスしようとしています。ワークツリー内のパスを使用してください。',
     'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts. deny_message: プロジェクトのスクリプトを使用してください。',
     'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review. deny_message: リモートコードのダウンロード実行は許可されていません。',
+    'Forbidden Package Managers: npm, pip, pip3, python -m pip, or any package manager other than pnpm, uv, go mod. deny_message: npm/pip は禁止です。pnpm または uv を使用してください。',
     'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine. deny_message: リポジトリ外のファイル削除は許可されていません。',
   ],
   environment: [

--- a/dot_claude/ccgate.jsonnet
+++ b/dot_claude/ccgate.jsonnet
@@ -11,7 +11,7 @@
     'Draft PR Creation: If the operation creates a pull request AND draft is true in tool_input_raw, allow immediately. If draft is false or absent, fallthrough.',
     'Local Development: Build, test, lint, format commands in the current repository.',
     'Git Feature Branch: Git operations on non-protected branches (not main, master, release/*, prod).',
-    'Package Manager Install: Package manager commands (npm install, go mod tidy, pip install, uv sync, etc.) in the current repository.',
+    'Package Manager Install: Package manager commands (pnpm install, go mod tidy, uv sync, etc.) in the current repository.',
   ],
   deny: [
     'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny. deny_message: git の破壊的操作です。ユーザーの明示的な指示を確認してください。',

--- a/dot_claude/ccgate.jsonnet
+++ b/dot_claude/ccgate.jsonnet
@@ -9,10 +9,16 @@
     'Read-Only Operations: GET requests, read-only API calls, or queries that do not modify state.',
     'Local Operations: Read-only work inside the current repository or current worktree.',
     'Draft PR Creation: If the operation creates a pull request AND draft is true in tool_input_raw, allow immediately. If draft is false or absent, fallthrough.',
+    'Local Development: Build, test, lint, format commands in the current repository.',
+    'Git Feature Branch: Git operations on non-protected branches (not main, master, release/*, prod).',
+    'Package Manager Install: Package manager commands (npm install, go mod tidy, pip install, uv sync, etc.) in the current repository.',
   ],
   deny: [
     'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny. deny_message: git の破壊的操作です。ユーザーの明示的な指示を確認してください。',
     'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate. deny_message: 現在のワークツリー外のチェックアウトにアクセスしようとしています。ワークツリー内のパスを使用してください。',
+    'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts. deny_message: プロジェクトのスクリプトを使用してください。',
+    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review. deny_message: リモートコードのダウンロード実行は許可されていません。',
+    'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine. deny_message: リポジトリ外のファイル削除は許可されていません。',
   ],
   environment: [
     '**Trusted repo**: The git repository the session started in.',

--- a/dot_claude/ccgate.jsonnet
+++ b/dot_claude/ccgate.jsonnet
@@ -14,11 +14,11 @@
     'Package Manager Install: Package manager commands (pnpm install, go mod tidy, uv sync, etc.) in the current repository.',
   ],
   deny: [
-    'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny. deny_message: Destructive git operation detected. Confirm explicit user instruction.',
-    'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate. deny_message: Accessing a path outside the current worktree. Use paths within the worktree.',
-    'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts. deny_message: Use project-defined scripts instead of direct tool invocation.',
-    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review. deny_message: Download-and-execute is not allowed.',
-    'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine. deny_message: Deleting files outside the repository is not allowed.',
+    'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny. deny_message: Destructive git operation detected. Confirm explicit user instruction. (Include the specific command or flags that triggered this denial.)',
+    'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate. deny_message: Accessing a path outside the current worktree. Use paths within the worktree. (Include the accessed path and the worktree root.)',
+    'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts. deny_message: Use project-defined scripts instead of direct tool invocation. (Include the detected command.)',
+    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review. deny_message: Download-and-execute is not allowed. (Include the detected pipeline.)',
+    'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine. deny_message: Deleting files outside the repository is not allowed. (Include the target path and the repo root.)',
   ],
   environment: [
     '**Trusted repo**: The git repository the session started in.',

--- a/dot_claude/ccgate.jsonnet
+++ b/dot_claude/ccgate.jsonnet
@@ -14,12 +14,11 @@
     'Package Manager Install: Package manager commands (pnpm install, go mod tidy, uv sync, etc.) in the current repository.',
   ],
   deny: [
-    'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny. deny_message: git の破壊的操作です。ユーザーの明示的な指示を確認してください。',
-    'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate. deny_message: 現在のワークツリー外のチェックアウトにアクセスしようとしています。ワークツリー内のパスを使用してください。',
-    'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts. deny_message: プロジェクトのスクリプトを使用してください。',
-    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review. deny_message: リモートコードのダウンロード実行は許可されていません。',
-    'Forbidden Package Managers: npm, pip, pip3, python -m pip, or any package manager other than pnpm, uv, go mod. deny_message: npm/pip は禁止です。pnpm または uv を使用してください。',
-    'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine. deny_message: リポジトリ外のファイル削除は許可されていません。',
+    'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny. deny_message: 検出された具体的な git 操作と、なぜ危険かを日本語で説明すること。',
+    'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate. deny_message: アクセスしようとしたパスと、現在のワークツリーのルートを示して、なぜ拒否されたか日本語で説明すること。',
+    'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts. deny_message: 検出されたコマンドと、代わりに使うべきプロジェクトのスクリプトを日本語で説明すること。',
+    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review. deny_message: 検出されたパイプラインの内容と、なぜ危険かを日本語で説明すること。',
+    'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine. deny_message: 削除対象のパスとリポジトリルートを示して、なぜ拒否されたか日本語で説明すること。',
   ],
   environment: [
     '**Trusted repo**: The git repository the session started in.',

--- a/dot_claude/ccgate.jsonnet
+++ b/dot_claude/ccgate.jsonnet
@@ -14,11 +14,11 @@
     'Package Manager Install: Package manager commands (pnpm install, go mod tidy, uv sync, etc.) in the current repository.',
   ],
   deny: [
-    'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny. deny_message: 検出された具体的な git 操作と、なぜ危険かを日本語で説明すること。',
-    'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate. deny_message: アクセスしようとしたパスと、現在のワークツリーのルートを示して、なぜ拒否されたか日本語で説明すること。',
-    'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts. deny_message: 検出されたコマンドと、代わりに使うべきプロジェクトのスクリプトを日本語で説明すること。',
-    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review. deny_message: 検出されたパイプラインの内容と、なぜ危険かを日本語で説明すること。',
-    'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine. deny_message: 削除対象のパスとリポジトリルートを示して、なぜ拒否されたか日本語で説明すること。',
+    'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny.',
+    'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate.',
+    'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts.',
+    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review.',
+    'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine.',
   ],
   environment: [
     '**Trusted repo**: The git repository the session started in.',

--- a/dot_claude/ccgate.jsonnet
+++ b/dot_claude/ccgate.jsonnet
@@ -14,11 +14,11 @@
     'Package Manager Install: Package manager commands (pnpm install, go mod tidy, uv sync, etc.) in the current repository.',
   ],
   deny: [
-    'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny. deny_message: Destructive git operation detected. Confirm explicit user instruction. (Include the specific command or flags that triggered this denial.)',
-    'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate. deny_message: Accessing a path outside the current worktree. Use paths within the worktree. (Include the accessed path and the worktree root.)',
-    'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts. deny_message: Use project-defined scripts instead of direct tool invocation. (Include the detected command.)',
-    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review. deny_message: Download-and-execute is not allowed. (Include the detected pipeline.)',
-    'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine. deny_message: Deleting files outside the repository is not allowed. (Include the target path and the repo root.)',
+    'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny. deny_message: Destructive git operation. Confirm explicit user instruction. Add relevant specifics.',
+    'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate. deny_message: Path outside current worktree. Add relevant specifics.',
+    'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts. deny_message: Direct tool invocation not allowed. Add relevant specifics.',
+    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review. deny_message: Download-and-execute not allowed. Add relevant specifics.',
+    'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine. deny_message: Deletion outside repository not allowed. Add relevant specifics.',
   ],
   environment: [
     '**Trusted repo**: The git repository the session started in.',

--- a/dot_claude/ccgate.jsonnet
+++ b/dot_claude/ccgate.jsonnet
@@ -14,11 +14,11 @@
     'Package Manager Install: Package manager commands (pnpm install, go mod tidy, uv sync, etc.) in the current repository.',
   ],
   deny: [
-    'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny. deny_message: Destructive git operation. Confirm explicit user instruction. Add relevant specifics.',
-    'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate. deny_message: Path outside current worktree. Add relevant specifics.',
-    'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts. deny_message: Direct tool invocation not allowed. Add relevant specifics.',
-    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review. deny_message: Download-and-execute not allowed. Add relevant specifics.',
-    'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine. deny_message: Deletion outside repository not allowed. Add relevant specifics.',
+    'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny. deny_message: Destructive git operation. Confirm explicit user instruction.',
+    'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate. deny_message: Path outside current worktree.',
+    'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts. deny_message: Direct tool invocation not allowed. Use project-defined scripts.',
+    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review. deny_message: Download-and-execute not allowed.',
+    'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine. deny_message: Deletion outside repository not allowed.',
   ],
   environment: [
     '**Trusted repo**: The git repository the session started in.',

--- a/dot_claude/ccgate.jsonnet
+++ b/dot_claude/ccgate.jsonnet
@@ -14,11 +14,11 @@
     'Package Manager Install: Package manager commands (pnpm install, go mod tidy, uv sync, etc.) in the current repository.',
   ],
   deny: [
-    'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny.',
-    'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate.',
-    'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts.',
-    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review.',
-    'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine.',
+    'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny. deny_message: Destructive git operation detected. Confirm explicit user instruction.',
+    'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate. deny_message: Accessing a path outside the current worktree. Use paths within the worktree.',
+    'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts. deny_message: Use project-defined scripts instead of direct tool invocation.',
+    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review. deny_message: Download-and-execute is not allowed.',
+    'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine. deny_message: Deleting files outside the repository is not allowed.',
   ],
   environment: [
     '**Trusted repo**: The git repository the session started in.',

--- a/dot_claude/permission-rules.libsonnet
+++ b/dot_claude/permission-rules.libsonnet
@@ -64,10 +64,17 @@ local rules = [
   {
     matcher: 'Bash',
     spec: 'Bash(npx*)',
+    reason: 'npx は禁止です。プロジェクトのスクリプトを使用してください。',
   },
   {
     matcher: 'Bash',
     spec: 'Bash(pnpx*)',
+    reason: 'pnpx は禁止です。プロジェクトのスクリプトを使用してください。',
+  },
+  {
+    matcher: 'Bash',
+    spec: 'Bash(bunx*)',
+    reason: 'bunx は禁止です。プロジェクトのスクリプトを使用してください。',
   },
   {
     matcher: 'Bash',

--- a/dot_claude/permission-rules.libsonnet
+++ b/dot_claude/permission-rules.libsonnet
@@ -58,7 +58,22 @@ local rules = [
   },
   {
     matcher: 'Bash',
+    spec: 'Bash(npm*)',
+    reason: 'npm は禁止です。pnpm を使用してください。',
+  },
+  {
+    matcher: 'Bash',
     spec: 'Bash(npx*)',
+  },
+  {
+    matcher: 'Bash',
+    spec: 'Bash(pip *)',
+    reason: 'pip は禁止です。uv を使用してください。',
+  },
+  {
+    matcher: 'Bash',
+    spec: 'Bash(pip3 *)',
+    reason: 'pip3 は禁止です。uv を使用してください。',
   },
   {
     matcher: 'Bash',

--- a/dot_claude/permission-rules.libsonnet
+++ b/dot_claude/permission-rules.libsonnet
@@ -67,6 +67,10 @@ local rules = [
   },
   {
     matcher: 'Bash',
+    spec: 'Bash(pnpx*)',
+  },
+  {
+    matcher: 'Bash',
     spec: 'Bash(pip *)',
     reason: 'pip は禁止です。uv を使用してください。',
   },

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -73,7 +73,7 @@ go = "1.26.1"
 "aqua:grafana/jsonnet-language-server" = "0.17.0"
 
 # Claude Code permission gate
-"go:github.com/tak848/ccgate" = "0.3.0"
+"go:github.com/tak848/ccgate" = "0.4.0"
 
 # Language Server
 "go:golang.org/x/tools/gopls" = "0.21.1"

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -1056,7 +1056,7 @@ checksum = "sha256:9b68112c913f45b7aebbf13c036721264bbba7e03a642f8f7490c561eebd1
 url = "https://dl.google.com/go/go1.26.1.windows-amd64.zip"
 
 [[tools."go:github.com/tak848/ccgate"]]
-version = "0.3.0"
+version = "0.4.0"
 backend = "go:github.com/tak848/ccgate"
 
 [[tools."go:golang.org/x/tools/gopls"]]


### PR DESCRIPTION
## Why

ccgate v0.4.0 で破壊的変更があり、global config (`~/.claude/ccgate.jsonnet`) が存在すると embedded defaults が適用されなくなった。
dotfiles の ccgate.jsonnet が全ルールを明示的に持つ必要がある。

## What

- `dot_claude/ccgate.jsonnet`: v0.4.0 で除去された built-in ルールを明示的に追加
  - allow: `Local Development`, `Git Feature Branch`, `Package Manager Install`
  - deny: `Direct Tool Invocation`, `Download and Execute`, `Out-of-Repo Deletion`
- `dot_config/mise/config.toml`: ccgate 0.3.0 → 0.4.0

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
