### PR TITLE
fix: Devin MCP プラグインの認証を headersHelper に変更

### DIFF
--- a/claude-plugins/devin/.mcp.json
+++ b/claude-plugins/devin/.mcp.json
@@ -2,8 +2,6 @@
   "devin": {
     "type": "http",
     "url": "https://mcp.devin.ai/mcp",
-    "headers": {
-      "Authorization": "Bearer ${DEVIN_API_KEY}"
-    }
+    "headersHelper": "echo '{\"Authorization\": \"Bearer '\"$DEVIN_API_KEY\"'\"}'"
   }
 }


### PR DESCRIPTION
## Why

PR #560 でカスタムマーケットプレイスに移行した Devin MCP プラグインが、別リポジトリで `needs authentication` となり OAuth フォールバックで接続失敗する。

```
Error: SDK auth failed: HTTP 404: Invalid OAuth error response: SyntaxError: JSON Parse error: Unexpected identifier "Not". Raw body: Not Found
```

プラグインの `.mcp.json` で `headers` に `${DEVIN_API_KEY}` を設定しているが、プラグインコンテキストでは環境変数展開が正しく処理されず、Claude Code が OAuth 認証を試みてしまう（[claude-code#21107](https://github.com/anthropics/claude-code/issues/21107) 関連）。

## What

`headers` を `headersHelper` に変更し、コマンド経由で Bearer token を動的に取得するようにした。`headersHelper` は OAuth メタデータチェックをバイパスするため、別リポジトリでも正しく認証される。

- `claude-plugins/devin/.mcp.json`: `headers` → `headersHelper` に変更
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
