### PR TITLE
fix: Devin MCP をプラグインから直接定義に戻す

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,6 @@
   },
   "plugins": [
     {
-      "name": "devin",
-      "description": "Devin MCP for AI session management and DeepWiki documentation",
-      "version": "1.0.0",
-      "source": "./claude-plugins/devin",
-      "category": "productivity"
-    },
-    {
       "name": "aws-knowledge",
       "description": "AWS Knowledge MCP for documentation search and recommendations",
       "version": "1.0.0",

--- a/claude-plugins/devin/.mcp.json
+++ b/claude-plugins/devin/.mcp.json
@@ -2,6 +2,8 @@
   "devin": {
     "type": "http",
     "url": "https://mcp.devin.ai/mcp",
-    "headersHelper": "echo '{\"Authorization\": \"Bearer '\"$DEVIN_API_KEY\"'\"}'"
+    "headers": {
+      "Authorization": "Bearer ${DEVIN_API_KEY}"
+    }
   }
 }

--- a/dot_claude/README.md
+++ b/dot_claude/README.md
@@ -2,21 +2,23 @@
 
 ## MCP 設定の管理
 
-MCP サーバーは **Claude Code プラグイン** として管理する。
+MCP サーバーは **Claude Code プラグイン** または **`modify_dot_claude.json` の直接定義** で管理する。
 
 ### プラグイン（カスタムマーケットプレイス）
 
 dotfiles リポジトリ自体がカスタムマーケットプレイス (`tak848-plugins`) として機能する。
-各 MCP サーバーは `claude-plugins/` 配下に独立したプラグインとして定義。
+認証不要な MCP サーバーは `claude-plugins/` 配下に独立したプラグインとして定義。
 
 - `.claude-plugin/marketplace.json` → マーケットプレイス定義
 - `claude-plugins/{name}/` → 各プラグイン（`.claude-plugin/plugin.json` + `.mcp.json`）
 - `settings.jsonnet` の `extraKnownMarketplaces` → マーケットプレイスの宣言的登録
 - `settings.jsonnet` の `enabledPlugins` → プラグインの有効化
 
+**注意**: Bearer token 認証が必要な MCP サーバー（Devin 等）はプラグインの `.mcp.json` で環境変数展開が機能しないため（[claude-code#9427](https://github.com/anthropics/claude-code/issues/9427)）、`modify_dot_claude.json` で直接定義する。
+
 ### 設定ファイル
 
-- `modify_dot_claude.json` → `~/.claude.json` の `remoteControlAtStartup` 設定と旧 MCP エントリの削除
+- `modify_dot_claude.json` → `~/.claude.json` の `mcpServers`（Devin）、`remoteControlAtStartup` 設定、旧 MCP エントリの削除
 - `settings.jsonnet` → `~/.claude/settings.json` を全体生成（Claude Code は書き込まない）
 - `ccgate.jsonnet` → `~/.claude/ccgate.jsonnet` の PermissionRequest 補助判定ルール（[tak848/ccgate](https://github.com/tak848/ccgate)）
 - `permission-rules.libsonnet` → `permissions.deny` と `PreToolUse` 用の deny ルールのマスタを管理

--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -17,7 +17,6 @@ local permissionRules = import 'permission-rules.libsonnet';
     'github@claude-plugins-official': true,
     'context7@claude-plugins-official': true,
     'gopls-lsp@claude-plugins-official': true,
-    'devin@tak848-plugins': true,
     'aws-knowledge@tak848-plugins': true,
     'temporal@tak848-plugins': true,
   },
@@ -160,10 +159,9 @@ local permissionRules = import 'permission-rules.libsonnet';
       'mcp__deepwiki__read_wiki_structure',
       'mcp__deepwiki__read_wiki_contents',
       'mcp__deepwiki__ask_question',
-      // Devin Plugin (tak848-plugins)
-      // ツール名はプラグイン化後に実機確認して修正すること
-      'mcp__plugin_devin_devin__ask_question',
-      'mcp__plugin_devin_devin__read_wiki_contents',
+      // Devin MCP (直接定義 — プラグインでは env var 展開が未対応)
+      'mcp__devin__ask_question',
+      'mcp__devin__read_wiki_contents',
       // Temporal Plugin (tak848-plugins)
       'mcp__plugin_temporal_temporal__*',
       // AWS Knowledge Plugin (tak848-plugins)

--- a/modify_dot_claude.json
+++ b/modify_dot_claude.json
@@ -7,12 +7,14 @@
 {{-   $data = fromJson .chezmoi.stdin -}}
 {{- end -}}
 {{- $mcpServers := index $data "mcpServers" | default dict -}}
-{{- /* 全ての旧 MCP エントリを削除（Plugin 移行済み） */ -}}
+{{- /* github, context7, aws-knowledge, temporal は Plugin に移行済み — 旧エントリを削除 */ -}}
 {{- $_ := unset $mcpServers "github" -}}
 {{- $_ := unset $mcpServers "context7" -}}
-{{- $_ := unset $mcpServers "devin" -}}
 {{- $_ := unset $mcpServers "aws-knowledge" -}}
 {{- $_ := unset $mcpServers "temporal" -}}
+{{- /* Devin MCP: プラグインでは env var 展開が機能しないため直接定義 (claude-code#9427) */ -}}
+{{- $devin := dict "type" "http" "url" "https://mcp.devin.ai/mcp" "headers" (dict "Authorization" "Bearer ${DEVIN_API_KEY}") -}}
+{{- $mcpServers = set $mcpServers "devin" $devin -}}
 {{- $data = set $data "mcpServers" $mcpServers -}}
 {{- /* remote-control を常時有効化 */ -}}
 {{- $data = set $data "remoteControlAtStartup" true -}}

--- a/run_onchange_after_50-claude-plugins.sh.tmpl
+++ b/run_onchange_after_50-claude-plugins.sh.tmpl
@@ -1,7 +1,5 @@
 #!/bin/bash
 # {{ include ".claude-plugin/marketplace.json" | sha256sum }}
-# {{ include "claude-plugins/devin/.claude-plugin/plugin.json" | sha256sum }}
-# {{ include "claude-plugins/devin/.mcp.json" | sha256sum }}
 # {{ include "claude-plugins/aws-knowledge/.claude-plugin/plugin.json" | sha256sum }}
 # {{ include "claude-plugins/aws-knowledge/.mcp.json" | sha256sum }}
 # {{ include "claude-plugins/temporal/.claude-plugin/plugin.json" | sha256sum }}
@@ -17,6 +15,6 @@ fi
 
 echo "Claude Code プラグインを更新中..."
 claude plugin marketplace update tak848-plugins || echo "WARN: marketplace update failed" >&2
-for plugin in devin aws-knowledge temporal; do
+for plugin in aws-knowledge temporal; do
     claude plugin install "${plugin}@tak848-plugins" || echo "WARN: plugin install failed: ${plugin}" >&2
 done


### PR DESCRIPTION
## Why

PR #560 で Devin MCP をカスタムマーケットプレイスのプラグインに移行したが、プラグインの `.mcp.json` では環境変数展開が機能しない既知の問題（[claude-code#9427](https://github.com/anthropics/claude-code/issues/9427)）により、別リポジトリで `needs authentication` → OAuth フォールバック → 404 エラーで接続失敗していた。

PR #570 で `headersHelper` への変更を試みたが、プラグインコンテキストではこちらも機能せず、dotfiles リポジトリでも接続不能に悪化。

公式プラグイン（claude-plugins-official）でも Bearer token 認証を `headers` フィールドで使っているプラグインは存在せず、認証付きプラグインは全て OAuth2 方式を採用している。現状のプラグインシステムでは Bearer token 認証が必要な MCP サーバーの配布に根本的な制約がある。

## What

Devin MCP のみ `modify_dot_claude.json` の直接定義に戻す。認証不要な aws-knowledge, temporal はプラグインのまま維持。

- `modify_dot_claude.json`: Devin MCP を直接 mcpServers に定義
- `dot_claude/settings.jsonnet`: `enabledPlugins` から `devin@tak848-plugins` を除外、permissions の Devin ツール名プレフィックスを `mcp__devin__` に戻す
- `.claude-plugin/marketplace.json`: Devin プラグインをマーケットプレイス定義から除外
- `run_onchange_after_50-claude-plugins.sh.tmpl`: Devin 関連のトリガーとインストールを除外
- `claude-plugins/devin/.mcp.json`: `headersHelper` を `headers` に戻す（プラグインファイルは参考用に残置）
- `dot_claude/README.md`: 認証付き MCP の制約について注記追加
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
