### PR TITLE
fix(claude): PreToolUse hook の暴発を回避するため additionalContext のみに変更

### DIFF
--- a/dot_claude/permission-rules.libsonnet
+++ b/dot_claude/permission-rules.libsonnet
@@ -1,11 +1,16 @@
 local shellSingleQuote(s) =
   "'" + std.strReplace(s, "'", "'\"'\"'") + "'";
 
+// Claude Code v2.1.105 以降、hooks[].if の評価が shell expansion ($(...), $$, ${VAR} 等) を
+// 含むコマンドで fall-open するリグレッションがあり、deny を返すと暴発で大量の false positive
+// deny が発生してコマンド実行が阻害される。
+// そこで permissionDecision は指定せず additionalContext のみで reason を Claude に届ける暫定措置。
+// 本物の deny 判定は permissions.deny 側 (permissionsDeny に同じ spec を登録済み) に完全委任する。
+// 上流修正が入ったら permissionDecision: 'deny' 方式に戻す。
 local preToolResponse(reason) = {
   hookSpecificOutput: {
     hookEventName: 'PreToolUse',
-    permissionDecision: 'deny',
-    permissionDecisionReason: '[auto-rejected: pattern matched] ' + reason,
+    additionalContext: '[deny hint] このコマンドは permissions.deny にマッチする可能性があります。背景: ' + reason,
   },
 };
 


### PR DESCRIPTION
## Why

Claude Code v2.1.105 で `hooks[].if` の評価が shell expansion (`$(...)`, `$$`, `${VAR}` 等) を含むコマンドに対して fall-open するリグレッションを踏んでいた。結果として、`dot_claude/permission-rules.libsonnet` から生成された全 reason 付き PreToolUse hook が一斉に `permissionDecision: "deny"` を返し、false positive で大量の auto-rejected が並ぶ状態になっていた。

### 実機で確認した症状

| コマンド | 結果 |
|---|---|
| `python --version` | 1 件 (`Bash(python*)` の reason のみ、正常) |
| `echo hello \| head -1` | 0 件 (pipe のみでは正常) |
| `echo $(date +%s)` | **17 件全 reason 付きルールが一斉 deny (暴発)** |
| `ln -s /dev/null /tmp/foo-$$` | 同上、`$$` でも暴発 |
| `docker exec -i $(docker ps -q ...) psql ...` | 同上、command substitution でも暴発 |

実害は「false positive deny で innocuous なコマンドが実行不能になる」こと。`echo $(date)` のような日常コマンドまで 18 件の deny エラーで阻害されていた。

### 公式 docs 確認

- https://code.claude.com/docs/en/hooks.md の `hookSpecificOutput` 仕様に `additionalContext` フィールドがあり、_"String added to Claude's context before the tool executes"_ と定義されている
- _"Deny and ask rules are still evaluated regardless of what the hook returns"_ — hook の返り値に関係なく `permissions.deny` 側の判定は評価される
- 実機検証で `permissionDecision` 省略 + `additionalContext` のみ返しても schema error にならず、Claude の context に system-reminder として届くことを確認

## What

`dot_claude/permission-rules.libsonnet` の `preToolResponse` 関数を書き換え:

- `permissionDecision: "deny"` を削除
- `permissionDecisionReason` を削除
- 代わりに `additionalContext` のみを返すように変更 (プレフィックス `[deny hint]`)

これにより、`if` が fall-open して全 hook が暴発しても、出力されるのは `additionalContext` のみになるので UI が deny でブロックされない (context 汚染は残るが、コマンド実行自体は阻害されない)。本物の deny 判定は `permissions.deny` (`permissionsDeny` に同じ spec を登録済み) に完全委任する。

上流 Claude Code の `if` 評価バグが修正されたら、`permissionDecision: "deny"` 方式 (UI 上で明示的に reject 表示される利点あり) に戻すことを別途検討。

### 動作モデル

| シナリオ | `if` 評価 | hook 出力 | permissions.deny | 最終挙動 |
|---|---|---|---|---|
| `python --version` | 1 件 match (正常) | 1 件 additionalContext | match → deny | deny + 背景説明付き |
| `echo $(date +%s)` | 17 件 fall-open | 17 件 additionalContext | no match | 通常実行、context 汚染のみ |
| `git commit --amend -m test` | 1 件 match | 1 件 additionalContext | match → deny | deny + 背景説明付き |
| `docker exec -i $(echo foo) sh -c 'echo ok'` | 17 件 fall-open | 17 件 additionalContext | no match | 通常実行 |

### 上流 issue

Anthropic claude-code 側にもリグレッションとして別途 issue 起票予定。

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
