### PR TITLE
chore: Claude Code のモデルを Opus 4.7 に更新

### DIFF
--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -201,7 +201,8 @@ local permissionRules = import 'permission-rules.libsonnet';
   },
   // model: 'claude-opus-4-1-20250805',
   // model: 'claude-opus-4-6',
-  model: 'claude-opus-4-6[1m]',
+  // model: 'claude-opus-4-6[1m]',
+  model: 'claude-opus-4-7[1m]',
   // model: 'opus',
 
   // 無効らしい

--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -249,7 +249,7 @@ local permissionRules = import 'permission-rules.libsonnet';
     CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR: '1',
     CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
   },
-  effortLevel: 'high',
+  effortLevel: 'xhigh',
   // alwaysThinkingEnabled は adaptive thinking (effortLevel) により不要
   // alwaysThinkingEnabled: true,  // https://github.com/anthropics/claude-code/issues/8780
   hooks: {


### PR DESCRIPTION
## Why

Opus 4.7 がリリースされたため。

## What

`dot_claude/settings.jsonnet` のモデル ID を `claude-opus-4-6[1m]` → `claude-opus-4-7[1m]` に更新。

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
