### PR TITLE
chore: ccgate を 0.4.2 に更新

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -73,7 +73,7 @@ go = "1.26.2"
 "aqua:grafana/jsonnet-language-server" = "0.17.0"
 
 # Claude Code permission gate
-"go:github.com/tak848/ccgate" = "0.4.1"
+"go:github.com/tak848/ccgate" = "0.4.2"
 
 # Language Server
 "go:golang.org/x/tools/gopls" = "0.21.1"

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -1056,7 +1056,7 @@ checksum = "sha256:98eb3570bade15cb826b0909338df6cc6d2cf590bc39c471142002db3832b
 url = "https://dl.google.com/go/go1.26.2.windows-amd64.zip"
 
 [[tools."go:github.com/tak848/ccgate"]]
-version = "0.4.1"
+version = "0.4.2"
 backend = "go:github.com/tak848/ccgate"
 
 [[tools."go:golang.org/x/tools/gopls"]]


### PR DESCRIPTION
## Why

`tak848/ccgate` v0.4.2 がリリースされたため追随する。

リリースノート: https://github.com/tak848/ccgate/releases/tag/v0.4.2

## What

- `dot_config/mise/config.toml`: `go:github.com/tak848/ccgate` を 0.4.1 → 0.4.2 に更新

### 上流の主な変更点

- `feat(metrics): record tool_input + automation rate + thousands separators (#34)`
- `fix(deps): update all non-major dependencies`

### 補足

- 破壊的変更なし。`dot_claude/ccgate.jsonnet` の設定変更は不要
- `dot_config/mise/mise.lock` は `.github/workflows/lockfiles-and-checksums.yaml` が自動更新する想定

(by Claude Code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
