### PR TITLE
fix(gwc): config.toml コピー対象を .codex/config.toml に限定し、venv 系を skip

### DIFF
--- a/dot_zsh/functions/git-worktree.zsh
+++ b/dot_zsh/functions/git-worktree.zsh
@@ -101,7 +101,7 @@ gwc() {
     local original_dir=$(pwd)
     local worktree_add_status=1
 
-    local default_copy_files=(".envrc.local" ".env.local" "settings.local.json" "CLAUDE.local.md" ".mcp.json" ".serena" "config.toml" ".gemini/settings.json" ".mise.local.toml" "ccgate.local.jsonnet")
+    local default_copy_files=(".envrc.local" ".env.local" "settings.local.json" "CLAUDE.local.md" ".mcp.json" ".serena" ".codex/config.toml" ".gemini/settings.json" ".mise.local.toml" "ccgate.local.jsonnet")
     local extra_copy_files=()
     local pr_ref=""
     local pr_mode=false
@@ -331,7 +331,7 @@ gwc() {
         if [ ${#find_name_args[@]} -gt 0 ]; then
             echo "\nSearching for and copying local config files: ${copy_files[*]}"
             local find_grouped_args=(\( "${find_name_args[@]}" \))
-            find "$root_dir" -path "$root_dir/.git" -prune -o -path "$root_dir/node_modules" -prune -o "${find_grouped_args[@]}" -print | while read -r src_path; do
+            find "$root_dir" \( -name .git -o -name node_modules -o -name .venv -o -name venv \) -prune -o "${find_grouped_args[@]}" -print | while read -r src_path; do
                 local rel_path=${src_path#$root_dir}
                 local dest_path="${worktree_path}${rel_path}"
                 


### PR DESCRIPTION
## Why

`gwc` の `default_copy_files` に裸の `config.toml` が含まれており、`find -name config.toml` で検索していたため、Python プロジェクトの `.venv/**/config.toml` 等の無関係なファイルまで新 worktree にコピーされてしまう問題があった。本来は `~/.codex/config.toml` 相当の `.codex/config.toml` だけを対象にしたい。

併せて、現状の `find` は root 直下の `.git` と `node_modules` しか prune しておらず、サブディレクトリの `node_modules` や `.venv` / `venv` を走査対象にしてしまい、誤マッチと性能劣化の温床になっていた。

## What

- `dot_zsh/functions/git-worktree.zsh` の `default_copy_files` で `config.toml` → `.codex/config.toml` に変更（既存のスラッシュ有無分岐により `-path "*/.codex/config.toml"` として検索される）
- `find` の prune 対象を `\( -name .git -o -name node_modules -o -name .venv -o -name venv \)` に変更
  - `node_modules` を root 直下限定から全階層に拡大
  - `.venv` / `venv` を新規追加

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
