### PR TITLE
chore: ccgate を 0.5.0 に更新

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -73,7 +73,7 @@ go = "1.26.2"
 "aqua:grafana/jsonnet-language-server" = "0.17.0"
 
 # Claude Code permission gate
-"go:github.com/tak848/ccgate" = "0.4.2"
+"go:github.com/tak848/ccgate" = "0.5.0"
 
 # Language Server
 "go:golang.org/x/tools/gopls" = "0.21.1"

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -1056,7 +1056,7 @@ checksum = "sha256:98eb3570bade15cb826b0909338df6cc6d2cf590bc39c471142002db3832b
 url = "https://dl.google.com/go/go1.26.2.windows-amd64.zip"
 
 [[tools."go:github.com/tak848/ccgate"]]
-version = "0.4.2"
+version = "0.5.0"
 backend = "go:github.com/tak848/ccgate"
 
 [[tools."go:golang.org/x/tools/gopls"]]


### PR DESCRIPTION
## Why

`tak848/ccgate` v0.5.0 がリリースされたため追随する。

リリースノート: https://github.com/tak848/ccgate/releases/tag/v0.5.0

## What

- `dot_config/mise/config.toml`: `go:github.com/tak848/ccgate` を 0.4.2 → 0.5.0 に更新

### 上流の主な変更点

- `feat: add fallthrough_strategy to force LLM uncertainty into allow/deny (#35)`
  - 新規 config フィールド `fallthrough_strategy`（`ask` / `deny` / `allow`）を追加
  - デフォルト `ask` のとき hook output は byte-identical（後方互換あり）

### 補足

- 破壊的変更なし。`fallthrough_strategy` 未指定（= `ask`）のため `dot_claude/ccgate.jsonnet` の変更は不要
- `dot_config/mise/mise.lock` は `.github/workflows/mise-lock.yaml` が自動更新する想定

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
