### PR TITLE
chore: ccgate を 0.5.1 に更新

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -74,7 +74,7 @@ go = "1.26.2"
 "aqua:grafana/jsonnet-language-server" = "0.17.0"
 
 # Claude Code permission gate
-"go:github.com/tak848/ccgate" = "0.5.0"
+"go:github.com/tak848/ccgate" = "0.5.1"
 
 # Language Server
 "go:golang.org/x/tools/gopls" = "0.21.1"

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -1088,7 +1088,7 @@ checksum = "sha256:98eb3570bade15cb826b0909338df6cc6d2cf590bc39c471142002db3832b
 url = "https://dl.google.com/go/go1.26.2.windows-amd64.zip"
 
 [[tools."go:github.com/tak848/ccgate"]]
-version = "0.5.0"
+version = "0.5.1"
 backend = "go:github.com/tak848/ccgate"
 
 [[tools."go:golang.org/x/tools/gopls"]]


### PR DESCRIPTION
## Why

`tak848/ccgate` v0.5.1 のリリース workflow に追随するため。

リリースノート: https://github.com/tak848/ccgate/releases/tag/v0.5.1

## What

- `dot_config/mise/config.toml`: `go:github.com/tak848/ccgate` を 0.5.0 → 0.5.1 に更新

### 補足

- `dot_config/mise/mise.lock` は `.github/workflows/mise-lock.yaml` が自動更新する想定

(by Claude Code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
