### PR TITLE
chore(ccgate): log/metrics ローテーションサイズを 100MB に引き上げ

### DIFF
--- a/dot_claude/ccgate.jsonnet
+++ b/dot_claude/ccgate.jsonnet
@@ -5,6 +5,7 @@
     model: 'claude-haiku-4-5',
     timeout_ms: 10000,
   },
+  log_max_size: 100 * 1024 * 1024,
   allow: [
     'Read-Only Operations: GET requests, read-only API calls, or queries that do not modify state.',
     'Local Operations: Read-only work inside the current repository or current worktree.',

--- a/dot_claude/ccgate.jsonnet
+++ b/dot_claude/ccgate.jsonnet
@@ -6,6 +6,7 @@
     timeout_ms: 10000,
   },
   log_max_size: 100 * 1024 * 1024,
+  metrics_max_size: 100 * 1024 * 1024,
   allow: [
     'Read-Only Operations: GET requests, read-only API calls, or queries that do not modify state.',
     'Local Operations: Read-only work inside the current repository or current worktree.',


### PR DESCRIPTION
## Why

デフォルトのローテーションサイズ（log 5MB / metrics 2MB）だと rotate が早すぎて履歴が短命化するため。metrics は分析用に保持したいので同じく 100MB に揃える。

スキーマ: https://github.com/tak848/ccgate/blob/main/ccgate.schema.json

## What

- `dot_claude/ccgate.jsonnet`:
  - `log_max_size: 100 * 1024 * 1024`（`ccgate.log` のローテサイズ、デフォルト 5MB → 100MB）
  - `metrics_max_size: 100 * 1024 * 1024`（`metrics.jsonl` のローテサイズ、デフォルト 2MB → 100MB）

(by Claude Code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
