### PR TITLE
chore(codex): model を gpt-5.5 に更新

### DIFF
--- a/dot_codex/modify_config.toml
+++ b/dot_codex/modify_config.toml
@@ -1,7 +1,7 @@
 {{- /* chezmoi:modify-template */ -}}
 #:schema https://developers.openai.com/codex/config-schema.json
 
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_context_window = 1000000
 model_auto_compact_token_limit = 500000
 model_reasoning_effort = "high"
@@ -81,11 +81,11 @@ url = "https://knowledge-mcp.global.api.aws"
 url = "https://temporal.mcp.kapa.ai"
 
 [profiles.fast]
-model = "gpt-5.2"
+model = "gpt-5.5"
 model_reasoning_effort = "medium"
 
 [profiles.xhigh]
-model = "gpt-5.2"
+model = "gpt-5.5"
 model_reasoning_effort = "xhigh"
 
 [profiles.codex]


### PR DESCRIPTION
## Why

gpt-5.5 がリリースされたため、Codex CLI のデフォルトモデルを 5.5 系に追従する。

## What

`dot_codex/modify_config.toml` を更新:

- main `model` : `gpt-5.4` → `gpt-5.5`
- `[profiles.fast]` : `gpt-5.2` → `gpt-5.5`
- `[profiles.xhigh]` : `gpt-5.2` → `gpt-5.5`
- `[profiles.codex]` / `codex-fast` / `codex-xhigh` : `gpt-5.3-codex` で据え置き（[Codex Models](https://developers.openai.com/codex/models) に `gpt-5.5-codex` は未掲載のため）

(by Claude Code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
