### PR TITLE
chore: ccgate 0.6.0 へ更新し hook を `ccgate claude` に明示化

### DIFF
--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -307,7 +307,7 @@ local autoModeRules = import 'auto-mode.libsonnet';
         hooks: [
           {
             type: 'command',
-            command: 'ccgate',
+            command: 'ccgate claude',
           },
         ],
       },

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -75,7 +75,7 @@ go = "1.26.2"
 "aqua:grafana/jsonnet-language-server" = "0.17.0"
 
 # Claude Code permission gate
-"aqua:tak848/ccgate" = "0.5.3"
+"aqua:tak848/ccgate" = "0.6.0"
 
 # Language Server
 "go:golang.org/x/tools/gopls" = "0.21.1"

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -767,32 +767,32 @@ checksum = "sha256:6c21422d1b786ed49937adcb3f23bebd169d32fef9b72ae8e77dc1bdb4c2a
 url = "https://github.com/starship/starship/releases/download/v1.25.0/starship-x86_64-pc-windows-msvc.zip"
 
 [[tools."aqua:tak848/ccgate"]]
-version = "0.5.3"
+version = "0.6.0"
 backend = "aqua:tak848/ccgate"
 
 [tools."aqua:tak848/ccgate"."platforms.linux-arm64"]
-checksum = "sha256:f8b9f582492ee1df88688e4d2361caa8a40978bc369cbe4b3792fcff6beb84fc"
-url = "https://github.com/tak848/ccgate/releases/download/v0.5.3/ccgate-linux-arm64.tar.gz"
+checksum = "sha256:81cdb001ab04ce3c1641e3071a25666842723b48a4d8a4fd85e687c2ede09b83"
+url = "https://github.com/tak848/ccgate/releases/download/v0.6.0/ccgate-linux-arm64.tar.gz"
 
 [tools."aqua:tak848/ccgate"."platforms.linux-arm64-musl"]
-checksum = "sha256:f8b9f582492ee1df88688e4d2361caa8a40978bc369cbe4b3792fcff6beb84fc"
-url = "https://github.com/tak848/ccgate/releases/download/v0.5.3/ccgate-linux-arm64.tar.gz"
+checksum = "sha256:81cdb001ab04ce3c1641e3071a25666842723b48a4d8a4fd85e687c2ede09b83"
+url = "https://github.com/tak848/ccgate/releases/download/v0.6.0/ccgate-linux-arm64.tar.gz"
 
 [tools."aqua:tak848/ccgate"."platforms.linux-x64"]
-checksum = "sha256:064e1b578f4e3b8a5caa86e7e952c1f4f3f462ec9e587134474d47bf30d34c4a"
-url = "https://github.com/tak848/ccgate/releases/download/v0.5.3/ccgate-linux-amd64.tar.gz"
+checksum = "sha256:3e6186d273a6dbba18008ecb3684ba07b0c59ac371b2b0305d2c9fffdaf4bf20"
+url = "https://github.com/tak848/ccgate/releases/download/v0.6.0/ccgate-linux-amd64.tar.gz"
 
 [tools."aqua:tak848/ccgate"."platforms.linux-x64-musl"]
-checksum = "sha256:064e1b578f4e3b8a5caa86e7e952c1f4f3f462ec9e587134474d47bf30d34c4a"
-url = "https://github.com/tak848/ccgate/releases/download/v0.5.3/ccgate-linux-amd64.tar.gz"
+checksum = "sha256:3e6186d273a6dbba18008ecb3684ba07b0c59ac371b2b0305d2c9fffdaf4bf20"
+url = "https://github.com/tak848/ccgate/releases/download/v0.6.0/ccgate-linux-amd64.tar.gz"
 
 [tools."aqua:tak848/ccgate"."platforms.macos-arm64"]
-checksum = "sha256:af63cea73d493ecb12332de9c7615970b3fd9c40233a1f56537fb33c7a7ff9d5"
-url = "https://github.com/tak848/ccgate/releases/download/v0.5.3/ccgate-darwin-arm64.tar.gz"
+checksum = "sha256:0e3a28622363542b3be6c3c0531e263291b228299cbd6f877f987eb1602904eb"
+url = "https://github.com/tak848/ccgate/releases/download/v0.6.0/ccgate-darwin-arm64.tar.gz"
 
 [tools."aqua:tak848/ccgate"."platforms.macos-x64"]
-checksum = "sha256:0faf2fb9cc7d8c25a0d11ce6da8fd18f1bceb88b2517fa80227bfd3e11180295"
-url = "https://github.com/tak848/ccgate/releases/download/v0.5.3/ccgate-darwin-amd64.tar.gz"
+checksum = "sha256:f17b2dbed0b56e7e3ba50109f6d0fa285fd6e1c37a1f5444d92452b0576dbb69"
+url = "https://github.com/tak848/ccgate/releases/download/v0.6.0/ccgate-darwin-amd64.tar.gz"
 
 [[tools."aqua:tamasfe/taplo"]]
 version = "0.10.0"


### PR DESCRIPTION
## Why

ccgate v0.6.0 で multi-target 化（Claude Code + OpenAI Codex CLI）が入った。リリースノート上 bare `ccgate` の hook 実行は後方互換ありだが、将来 Codex 用に分岐していくのを見越して hook command を `ccgate claude` に明示化しておく。

[release notes (v0.6.0)](https://github.com/tak848/ccgate/releases/tag/v0.6.0)

### 破壊的変更の影響レビュー（dotfiles リポジトリへの影響: なし）

- `ccgate init` / `ccgate metrics` 削除 → dotfiles 内では bare `ccgate`（hook 用途）のみ使用しており該当なし
- root-level `{repo_root}/ccgate.local.jsonnet` 廃止 → dotfiles では未使用
- project-local `allow:` / `deny:` / `environment:` が REPLACE 化 → `dot_claude/ccgate.jsonnet` は global config (`~/.claude/ccgate.jsonnet`) でリリースノート明記の通りセマンティクス変更なし
- Codex hook の Windows 非対応 → macOS のみ運用なので影響なし
- metrics/log のパス移行は各端末側の作業（ローカルで提供されたワンライナーを実行）。dotfiles レポ自体には差分なし

## What

- `dot_config/mise/config.toml`: `aqua:tak848/ccgate` を `0.5.3` → `0.6.0`
- `dot_claude/settings.jsonnet`: `PermissionRequest` hook の `command` を `'ccgate'` → `'ccgate claude'`
- `mise.lock` は Renovate ワークフロー (`mise-lock.yaml`) に任せるため本 PR では更新しない

(by Claude Code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
