### PR TITLE
feat: Codex CLI に ccgate hook を追加

### DIFF
--- a/dot_codex/hooks.json
+++ b/dot_codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ccgate codex",
+            "statusMessage": "ccgate evaluating request"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Why

ccgate v0.6.0 で追加された Codex CLI 対応 (`ccgate codex`) を Codex CLI 側にも登録する。Claude Code 側は #617 で `ccgate claude` に移行済み。

参考: [ccgate docs/codex.md](https://github.com/tak848/ccgate/blob/v0.6.0/docs/codex.md)

### 注意

- ccgate docs に明記の通り **Codex hooks は upstream-experimental**。スキーマや挙動が予告なく変わる可能性あり
- Windows は upstream 未対応（macOS/Linux のみ）

## What

- `dot_codex/hooks.json` を新規作成し `PermissionRequest` で `ccgate codex` を呼ぶ
- ccgate docs で "recommended" とされる `hooks.json` 形式を採用（`config.toml` への追記ではない）
- Codex CLI 側は通常このファイルを書き換えないため modify テンプレートではなく static ファイルで管理
- allow / deny / environment は ccgate 同梱の defaults (`internal/cmd/codex/defaults.jsonnet`) に委譲。独自設定が必要になれば後追いで `dot_codex/ccgate.jsonnet` を追加

(by Claude Code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
