### PR TITLE
feat: ant CLI (Anthropic API CLI) を global mise に追加

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -77,6 +77,9 @@ go = "1.26.2"
 # Claude Code permission gate
 "aqua:tak848/ccgate" = "0.7.0"
 
+# Anthropic API CLI（aqua registry 未登録のため go backend）
+"go:github.com/anthropics/anthropic-cli/cmd/ant" = "v1.6.0"
+
 # Language Server
 "go:golang.org/x/tools/gopls" = "0.21.1"
 "aqua:rust-lang/rust-analyzer" = "2025-12-01"

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -1143,6 +1143,10 @@ url = "https://dl.google.com/go/go1.26.2.darwin-amd64.tar.gz"
 checksum = "sha256:98eb3570bade15cb826b0909338df6cc6d2cf590bc39c471142002db3832b708"
 url = "https://dl.google.com/go/go1.26.2.windows-amd64.zip"
 
+[[tools."go:github.com/anthropics/anthropic-cli/cmd/ant"]]
+version = "1.6.0"
+backend = "go:github.com/anthropics/anthropic-cli/cmd/ant"
+
 [[tools."go:golang.org/x/tools/gopls"]]
 version = "0.21.1"
 backend = "go:golang.org/x/tools/gopls"


### PR DESCRIPTION
## Why

Anthropic 公式の API CLI [`ant`](https://github.com/anthropics/anthropic-cli) を手元で使えるようにするため、global の mise 管理に加える。

## What

- `dot_config/mise/config.toml` に `"go:github.com/anthropics/anthropic-cli/cmd/ant" = "v1.6.0"` を追加
- backend 選定理由
  - aqua registry 未登録（`pkgs/anthropics/` 配下は `claude-code` のみ）
  - GitHub Release のアセット名が `ant_VERSION_macos_ARCH.zip` と `darwin` 表記でないため mise github backend の自動検出が不安定
  - 既に gopls で go backend の前例あり、Go ランタイムも同 config 内で管理済み
- `mise.lock` 更新は既存方針通り Renovate ワークフロー任せ（go backend は checksum 反映されない可能性あり）

(by Claude Code)
