### PR TITLE
fix: Renovate gitIgnoredAuthors に tak-automation[bot] を追加

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,7 @@
   major: { labels: ["renovate", "update_major"] },
   gitIgnoredAuthors: [
     "github-actions[bot]@users.noreply.github.com",
+    "221638520+tak-automation[bot]@users.noreply.github.com",
   ],
   customManagers: [
     {


### PR DESCRIPTION
## Why

#626 で workflow の commit を `createCommitOnBranch` (GraphQL) 経由に切り替えた結果、commit の author が GitHub App (`tak-automation[bot]`) になった。これにより Renovate が「Renovate 以外の編集者がいる」と判定し、PR の自動 rebase を停止してしまう事象が発生した。

実例: #628 の [警告コメント](https://github.com/tak848/dotfiles/pull/628#issuecomment-4403464779)

> Renovate will not automatically rebase this PR, because it does not recognize the last commit author and assumes somebody else may have edited the PR.

## What

`.github/renovate.json5` の `gitIgnoredAuthors` に `tak-automation[bot]` の email (`221638520+tak-automation[bot]@users.noreply.github.com`) を追加し、Renovate が当該 bot の commit を自身の PR への許可された編集として認識するようにした。

(by Claude Code)
