### PR TITLE
chore: gopls-lsp プラグインの一律有効化を無効化

### DIFF
--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -23,7 +23,8 @@ local autoModeRules = import 'auto-mode.libsonnet';
   enabledPlugins: {
     'github@claude-plugins-official': true,
     'context7@claude-plugins-official': true,
-    'gopls-lsp@claude-plugins-official': true,
+    // gopls-lsp は重いため一律有効化しない。必要なプロジェクトで個別に有効化する。
+    // 'gopls-lsp@claude-plugins-official': true,
     'aws-knowledge@tak848-plugins': true,
     'temporal@tak848-plugins': true,
     'codex@openai-codex': true,


### PR DESCRIPTION
## Why

`gopls-lsp@claude-plugins-official` プラグインは動作が重いため、グローバルで一律有効化する運用が辛い。

## What

- `dot_claude/settings.jsonnet` の `enabledPlugins` から `gopls-lsp@claude-plugins-official` の自動有効化をコメントアウト
- 必要なプロジェクトで個別に有効化する運用に切り替える方針をコメントで明記

(by Claude Code)