### PR TITLE
feat: cmux を cask に追加

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -3,6 +3,7 @@ packages:
     taps:
       base:
         - laishulu/homebrew
+        - manaflow-ai/cmux
         - nikitabobko/tap
     brews:
       base:
@@ -13,6 +14,7 @@ packages:
     casks:
       base:
         - ghostty # ターミナル
+        - manaflow-ai/cmux/cmux # AI コーディングエージェント向け macOS ターミナル
         - nikitabobko/tap/aerospace # タイリングウィンドウマネージャ
         - macvim
         - obsidian


### PR DESCRIPTION
## Why

AI コーディングエージェント（Claude Code / Codex 等）を並列で扱うための macOS ネイティブターミナル [manaflow-ai/cmux](https://github.com/manaflow-ai/cmux) を常用ツールとして導入したいため。

## What

- `.chezmoidata/packages.yaml` に Homebrew tap `manaflow-ai/cmux` と cask `manaflow-ai/cmux/cmux` を追加

(by Claude Code)