### PR TITLE
chore: gwc のデフォルトコピー対象から ccgate.local.jsonnet を削除

### DIFF
--- a/dot_zsh/functions/git-worktree.zsh
+++ b/dot_zsh/functions/git-worktree.zsh
@@ -101,7 +101,7 @@ gwc() {
     local original_dir=$(pwd)
     local worktree_add_status=1
 
-    local default_copy_files=(".envrc.local" ".env.local" "settings.local.json" "CLAUDE.local.md" ".mcp.json" ".serena" ".codex/config.toml" ".gemini/settings.json" ".mise.local.toml" "ccgate.local.jsonnet")
+    local default_copy_files=(".envrc.local" ".env.local" "settings.local.json" "CLAUDE.local.md" ".mcp.json" ".serena" ".codex/config.toml" ".gemini/settings.json" ".mise.local.toml")
     local extra_copy_files=()
     local pr_ref=""
     local pr_mode=false


### PR DESCRIPTION
## Why

ccgate が worktree を認識するようになり、新規 worktree ごとに `ccgate.local.jsonnet` をコピーする必要がなくなったため。

## What

- `dot_zsh/functions/git-worktree.zsh` の `gwc` の `default_copy_files` から `ccgate.local.jsonnet` を削除

(by Claude Code)