### PR TITLE
fix: aube trustPolicy=no-downgrade で tinyexec@1.2.2 を例外化

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -5,6 +5,12 @@ experimental = true
 lockfile = true
 locked = false                                 # npm backend が checksum 未対応のため
 
+[env]
+# aube (mise の npm backend が内部で使う) の trustPolicy=no-downgrade が
+# tinyexec@1.2.2 を拒否するため、このバージョンだけ exclude。
+# 詳細は dot_config/mise/config.toml の [env] コメント参照。
+NPM_CONFIG_TRUST_POLICY_EXCLUDE = "tinyexec@1.2.2"
+
 [tools]
 # このリポジトリで使うランタイム
 node = "24.16.0"

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -12,6 +12,16 @@ locked = false
 # dotfiles 用の aqua backend では checksum verification のみに寄せる
 cosign = false
 
+[env]
+# aube (mise の npm backend が内部で使う) の trustPolicy=no-downgrade が
+# tinyexec@1.2.2 を ERR_AUBE_TRUST_DOWNGRADE で拒否するため、
+# このバージョンだけ exclude する。
+# - tinyexec@1.0.2 は GitHub Actions OIDC の trusted publisher で publish
+# - tinyexec@1.2.2 (現 latest) はメンテナ個人 publish で provenance attestation のみ
+# バージョンピンでの除外なので、1.2.3+ や他パッケージでは no-downgrade ガードが残る。
+# 参考: https://github.com/tak848/dotfiles/actions/runs/26555130050
+NPM_CONFIG_TRUST_POLICY_EXCLUDE = "tinyexec@1.2.2"
+
 [tools]
 # ============================================
 # ランタイム（core backend）


### PR DESCRIPTION
## Why

Renovate の PR #654 / #657 を含む `ci.yaml` の **Setup mise** ステップが、ある時から急に失敗するようになった。

エラー本体:

```
ERR_AUBE_TRUST_DOWNGRADE
  ╰─▶ trust downgrade for tinyexec@1.2.2 (trustPolicy=no-downgrade): earlier
      published version 1.0.2 had trusted publisher but this version has
      provenance attestation
mise ERROR Failed to install npm:difit@5.0.1: ... aube exited with non-zero status: exit code 23
```

### 原因

`mise` の npm backend は内部で `github:endevco/aube` を使う (`npm.package_manager=auto` のとき aube が優先) 。aube は `trustPolicy='no-downgrade'` をデフォルト適用し、以下の差分を「supply-chain incident の疑い」として install を拒否する:

- `tinyexec@1.0.2`: GitHub Actions OIDC の **trusted publisher** で publish (`_npmUser.trustedPublisher.id = "github"`)
- `tinyexec@1.2.2` (2026-05-23 publish、現 latest): メンテナ個人 (`43081j`) が publish。provenance attestation はあるが trustedPublisher は無い

`npm:difit@5.0.1` の依存ツリーに tinyexec が含まれるため、毎回ここで止まる。tinyexec のメンテナが trusted publisher 経由で再リリースしない限り永続的な事象。

参考: https://github.com/tak848/dotfiles/actions/runs/26555130050

## What

- `dot_config/mise/config.toml` と `.mise.toml` の双方に `[env]` を追加し、`NPM_CONFIG_TRUST_POLICY_EXCLUDE="tinyexec@1.2.2"` を渡す
- **バージョンピンでの除外**としているため、`tinyexec@1.2.3` 以降や他パッケージに対しては aube の `no-downgrade` ガードを引き続き効かせる
- `trustPolicy=off` で全体無効化したり、`npm.package_manager=pnpm` への切り替えは行わず、aube の安全網は最大限維持する方針

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->