### PR TITLE
fix: Renovate の mise artifact 更新を skip して trust エラー警告を抑止

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,6 +35,16 @@
       minimumReleaseAge: "24 hours",
     },
     {
+      // mise.lock の更新は CI 側の lockfiles-and-checksums.yaml ワークフローに任せる。
+      // Mend Cloud の allowedEnv (BUN_*, GO*, GRADLE_OPTS, RUSTC_BOOTSTRAP, PNPM_WORKERS,
+      // PNPM_MAX_WORKERS) と allowedCommands (git add --all / git reset / pwd) には
+      // MISE_TRUSTED_CONFIG_PATHS も `mise trust` も含まれず、Renovate の mise
+      // post-update artifact 生成が trust エラーで毎回失敗するため、警告を抑止する。
+      description: "Skip mise lockfile artifact update on Mend Cloud (handled by lockfiles-and-checksums.yaml)",
+      matchManagers: ["mise"],
+      skipArtifactsUpdate: true,
+    },
+    {
       description: "Claude Code: independent PR, no age gate",
       matchPackageNames: ["anthropics/claude-code"],
       groupName: "claude-code",


### PR DESCRIPTION
## Why

Renovate PR (#651 以降) に毎回 ⚠️ **Artifact update problem** が出るようになっていた。

\`\`\`
mise ERROR error parsing config file: /tmp/renovate/repos/github/tak848/dotfiles/dot_config/mise/config.toml
mise ERROR Config files in /tmp/renovate/repos/github/tak848/dotfiles/dot_config/mise/config.toml are not trusted.
Trust them with \`mise trust\`. See https://mise.en.dev/cli/trust.html
Command failed: mise lock aqua:anthropics/claude-code
\`\`\`

### 原因

mise の最近のバージョン (v2026.5.13 / 2026-05-21 リリース前後) で config trust 検査の挙動が変わったか強化された結果、Renovate が \`/tmp/renovate/repos/.../dot_config/mise/config.toml\` を読むときに毎回拒否されるようになった (境界は PR #648 マージまで OK → PR #651 から発生)。

### Mend Cloud 制約

run ログ (\`developer.mend.io\`) を確認した結果、Mend Renovate Cloud の以下のホワイトリストでは **mise trust 関連を渡せない**:

| 項目 | 許可リスト |
|---|---|
| \`allowedEnv\` | \`BUN_CONFIG_MAX_HTTP_REQUESTS\`, \`GO*\`, \`GRADLE_OPTS\`, \`RUSTC_BOOTSTRAP\`, \`PNPM_WORKERS\`, \`PNPM_MAX_WORKERS\` |
| \`allowedCommands\` | \`^git add --all\$\`, \`^git reset\$\`, \`^pwd\$\` |

→ \`MISE_TRUSTED_CONFIG_PATHS\` を \`env\` で渡す案も、\`postUpgradeTasks\` で \`mise trust\` を実行する案も Mend Cloud では物理的に不可能。

## What

- \`renovate.json5\` の \`packageRules\` に **mise manager 限定** で \`skipArtifactsUpdate: true\` を追加
- これで Renovate は mise の lockfile (\`mise.lock\`) を更新しなくなり、artifact update problem 警告が出なくなる
- mise.lock の更新は既存の \`lockfiles-and-checksums.yaml\` ワークフロー (push トリガー) が Renovate PR マージ後に再生成・コミットするため、機能的な穴は無い
- aqua / customManager (\`.mise-bootstrap-version\`) など他 manager の artifact 更新には影響なし

## 検討した他案

| 案 | 不採用理由 |
|---|---|
| \`env.MISE_TRUSTED_CONFIG_PATHS\` 設定 | Mend Cloud の \`allowedEnv\` 非対応 |
| \`postUpgradeTasks\` で \`mise trust\` 実行 | Mend Cloud の \`allowedCommands\` 非対応 |
| self-hosted Renovate (GitHub Action) | 大工事 (cron / token / 既存 PR 移行)、今回の警告抑止には過剰 |

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->