### PR TITLE
chore: ccgate の minimumReleaseAge を 0 にして即時更新を受ける

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,6 +59,12 @@
       extractVersion: "^rust-v(?<version>.+)$",
     },
     {
+      description: "ccgate: 自作ツールなので age gate なし",
+      matchPackageNames: ["tak848/ccgate"],
+      groupName: "ccgate",
+      minimumReleaseAge: "0 hours",
+    },
+    {
       description: "Use node versioning for Node.js (LTS only)",
       matchPackageNames: ["nodejs/node"],
       versioning: "node",


### PR DESCRIPTION
## Why

`tak848/ccgate` は自作ツールなので、リリース直後から更新 PR を受け取りたい。デフォルトの 24h age gate を待つ必要がない。

## What

`.github/renovate.json5` の `packageRules` に `tak848/ccgate` 用ルールを追加し、`minimumReleaseAge: "0 hours"` を設定。既存の `anthropics/claude-code` / `openai/codex` と同じパターン。

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->