### PR TITLE
feat: sudo 事前認証を必要時のみに限定し linuxbrew を廃止

### DIFF
--- a/.chezmoitemplates/path-setup.tmpl
+++ b/.chezmoitemplates/path-setup.tmpl
@@ -8,8 +8,6 @@ export PATH="/opt/homebrew/bin:$PATH"
 {{-   else }}
 export PATH="/usr/local/bin:$PATH"
 {{-   end }}
-{{- else if eq .chezmoi.os "linux" }}
-export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
 {{- end }}
 export PATH="${XDG_DATA_HOME}/aquaproj-aqua/bin:$PATH"
 export AQUA_GLOBAL_CONFIG="${AQUA_GLOBAL_CONFIG:-}:${XDG_CONFIG_HOME}/aquaproj-aqua/aqua.yaml"

--- a/dot_zprofile.tmpl
+++ b/dot_zprofile.tmpl
@@ -1,12 +1,10 @@
-# Homebrew shellenv (ログイン時1回のみ)
+# Homebrew shellenv (ログイン時1回のみ、macOS のみ)
 {{- if eq .chezmoi.os "darwin" }}
 {{-   if eq .chezmoi.arch "arm64" }}
 [[ -x "/opt/homebrew/bin/brew" ]] && eval "$(/opt/homebrew/bin/brew shellenv)"
 {{-   else }}
 [[ -x "/usr/local/bin/brew" ]] && eval "$(/usr/local/bin/brew shellenv)"
 {{-   end }}
-{{- else if eq .chezmoi.os "linux" }}
-[[ -x "/home/linuxbrew/.linuxbrew/bin/brew" ]] && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 {{- end }}
 
 # mise shims (非インタラクティブセッション用、IDE連携)

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -16,9 +16,6 @@ export PATH="/opt/homebrew/bin:$PATH"
 {{-   else }}
 export PATH="/usr/local/bin:$PATH"
 {{-   end }}
-{{- else if eq .chezmoi.os "linux" }}
-# Linux: Homebrew (非ログインシェルでも PATH に含める)
-export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
 {{- end }}
 export PATH="${XDG_DATA_HOME}/aquaproj-aqua/bin:$PATH"
 

--- a/run_once_before_00-install-essentials.sh.tmpl
+++ b/run_once_before_00-install-essentials.sh.tmpl
@@ -7,12 +7,28 @@ export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 
 echo "=== chezmoi 初回セットアップ ==="
 
-# sudo 権限を事前に要求（パスワード入力）
-echo "セットアップには管理者権限が必要です。"
-sudo -v
+# sudo が必要になる処理が走るかを事前に判定し、必要なときだけ認証を取る
+NEEDS_SUDO=false
+{{- if eq .chezmoi.os "darwin" }}
+{{-   if eq .chezmoi.arch "arm64" }}
+BREW_PATH="/opt/homebrew/bin/brew"
+{{-   else }}
+BREW_PATH="/usr/local/bin/brew"
+{{-   end }}
+# Homebrew インストーラが初手で sudo を要求するため
+[ -x "$BREW_PATH" ] || NEEDS_SUDO=true
+{{- end }}
+{{- if eq .chezmoi.os "linux" }}
+# zsh インストール用の apt/dnf/pacman で sudo が必要
+command -v zsh >/dev/null 2>&1 || NEEDS_SUDO=true
+{{- end }}
 
-# sudo 認証を維持（バックグラウンドで更新）
-while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
+if [ "$NEEDS_SUDO" = true ]; then
+  echo "セットアップには管理者権限が必要です。"
+  sudo -v
+  # sudo 認証を維持（バックグラウンドで更新）
+  while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
+fi
 
 # 0. zsh インストール（Linux の場合）
 {{- if eq .chezmoi.os "linux" }}
@@ -34,17 +50,8 @@ if [ "$SHELL" != "$(which zsh)" ]; then
 fi
 {{- end }}
 
-# 1. Homebrew インストール
+# 1. Homebrew インストール（macOS のみ）
 {{- if eq .chezmoi.os "darwin" }}
-{{-   if eq .chezmoi.arch "arm64" }}
-BREW_PATH="/opt/homebrew/bin/brew"
-{{-   else }}
-BREW_PATH="/usr/local/bin/brew"
-{{-   end }}
-{{- else if eq .chezmoi.os "linux" }}
-BREW_PATH="/home/linuxbrew/.linuxbrew/bin/brew"
-{{- end }}
-
 if [ ! -x "$BREW_PATH" ]; then
   echo "Installing Homebrew..."
   NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -54,6 +61,7 @@ fi
 if [ -x "$BREW_PATH" ]; then
   eval "$($BREW_PATH shellenv)"
 fi
+{{- end }}
 
 # 2. zinit インストール
 ZINIT_HOME="$XDG_DATA_HOME/zinit/zinit.git"

--- a/run_once_before_00-install-essentials.sh.tmpl
+++ b/run_once_before_00-install-essentials.sh.tmpl
@@ -7,7 +7,11 @@ export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 
 echo "=== chezmoi 初回セットアップ ==="
 
-# sudo が必要になる処理が走るかを事前に判定し、必要なときだけ認証を取る
+# sudo は remote/container 環境では使えないことがある。
+# - NEEDS_SUDO: 本来 sudo が必要になる処理が走るかどうか
+# - HAS_SUDO:   sudo を実際に使えるか（コマンド存在 + 認証成功）
+# 必要かつ使える場合のみ事前認証して keepalive を回す。
+# 使えない場合は sudo 必須の処理を skip し、interactive にならないようにする。
 NEEDS_SUDO=false
 {{- if eq .chezmoi.os "darwin" }}
 {{-   if eq .chezmoi.arch "arm64" }}
@@ -19,42 +23,63 @@ BREW_PATH="/usr/local/bin/brew"
 [ -x "$BREW_PATH" ] || NEEDS_SUDO=true
 {{- end }}
 {{- if eq .chezmoi.os "linux" }}
-# zsh インストール用の apt/dnf/pacman で sudo が必要
+# zsh インストール (apt/dnf/pacman) で sudo が必要
 command -v zsh >/dev/null 2>&1 || NEEDS_SUDO=true
 {{- end }}
 
-if [ "$NEEDS_SUDO" = true ]; then
-  echo "セットアップには管理者権限が必要です。"
-  sudo -v
-  # sudo 認証を維持（バックグラウンドで更新）
-  while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
+HAS_SUDO=false
+if [ "$NEEDS_SUDO" = true ] && command -v sudo >/dev/null 2>&1; then
+  # まず noninteractive で試す（passwordless sudo な環境向け）
+  if sudo -n -v 2>/dev/null; then
+    HAS_SUDO=true
+  elif [ -t 0 ]; then
+    # tty があれば対話的にパスワードを取得
+    echo "セットアップには管理者権限が必要です。"
+    if sudo -v; then
+      HAS_SUDO=true
+    fi
+  fi
+  if [ "$HAS_SUDO" = true ]; then
+    # sudo 認証を維持（バックグラウンドで更新）
+    while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
+  fi
 fi
 
 # 0. zsh インストール（Linux の場合）
 {{- if eq .chezmoi.os "linux" }}
-if ! command -v zsh &> /dev/null; then
-  echo "Installing zsh..."
-  {{- if or (eq .chezmoi.osRelease.id "ubuntu") (eq .chezmoi.osRelease.id "debian") }}
-  sudo apt update && sudo apt install -y zsh
-  {{- else if or (eq .chezmoi.osRelease.id "fedora") (eq .chezmoi.osRelease.id "rhel") (eq .chezmoi.osRelease.id "centos") }}
-  sudo dnf install -y zsh
-  {{- else if eq .chezmoi.osRelease.id "arch" }}
-  sudo pacman -S --noconfirm zsh
-  {{- end }}
+if ! command -v zsh >/dev/null 2>&1; then
+  if [ "$HAS_SUDO" = true ]; then
+    echo "Installing zsh..."
+    {{- if or (eq .chezmoi.osRelease.id "ubuntu") (eq .chezmoi.osRelease.id "debian") }}
+    sudo apt update && sudo apt install -y zsh
+    {{- else if or (eq .chezmoi.osRelease.id "fedora") (eq .chezmoi.osRelease.id "rhel") (eq .chezmoi.osRelease.id "centos") }}
+    sudo dnf install -y zsh
+    {{- else if eq .chezmoi.osRelease.id "arch" }}
+    sudo pacman -S --noconfirm zsh
+    {{- end }}
+  else
+    echo "[skip] zsh が未インストールですが sudo が使えないためスキップします。"
+  fi
 fi
 
-# デフォルトシェルを zsh に変更
-if [ "$SHELL" != "$(which zsh)" ]; then
+# デフォルトシェルを zsh に変更（interactive 化を避けるため、失敗は no-op）
+if command -v zsh >/dev/null 2>&1 && [ "$SHELL" != "$(command -v zsh)" ]; then
   echo "Changing default shell to zsh..."
-  chsh -s "$(which zsh)"
+  if ! chsh -s "$(command -v zsh)" </dev/null >/dev/null 2>&1; then
+    echo "[skip] chsh に失敗しました。手動で 'chsh -s $(command -v zsh)' を実行してください。"
+  fi
 fi
 {{- end }}
 
-# 1. Homebrew インストール（macOS のみ）
+# 1. Homebrew インストール（macOS のみ、sudo が使える場合のみ）
 {{- if eq .chezmoi.os "darwin" }}
 if [ ! -x "$BREW_PATH" ]; then
-  echo "Installing Homebrew..."
-  NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  if [ "$HAS_SUDO" = true ]; then
+    echo "Installing Homebrew..."
+    NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  else
+    echo "[skip] Homebrew が未インストールですが sudo が使えないためスキップします。"
+  fi
 fi
 
 # Homebrew を PATH に追加（この時点では zshenv 未展開）


### PR DESCRIPTION
## Why

`run_once_before_00-install-essentials.sh.tmpl` が無条件で `sudo -v` と sudo keepalive を実行していたため、本来 sudo が不要な環境でも `chezmoi update` のたびにパスワードを要求する可能性があった。実態を整理すると:

- スクリプト内で実際に `sudo` を呼ぶのは Linux 側の zsh インストール (`apt`/`dnf`/`pacman`) と `chsh` のみ。
- macOS 側でスクリプト本体は `sudo` を直接呼ばないが、Homebrew のインストーラ (`install.sh`) は初手で sudo を要求する。
- 既に brew (macOS) / zsh (Linux) が入っていれば、その後 sudo を必要とする処理は一切走らない。
- これまで Linux でも linuxbrew をインストールしていたが、`.chezmoidata/packages.yaml` は darwin only で、本リポジトリ内では linuxbrew を一切利用していなかった。

## What

- `run_once_before_00-install-essentials.sh.tmpl`
  - 無条件の `sudo -v` / keepalive を削除し、「darwin で brew 未インストール」または「linux で zsh 未インストール」のときだけ事前認証を取るロジックに置換。
  - `BREW_PATH` の定義を OS 判定の冒頭に移動し、Homebrew インストールセクション全体を `{{ if eq .chezmoi.os "darwin" }}` で囲んで macOS 専用に。
- linuxbrew 全廃
  - `dot_zprofile.tmpl`: `else if eq .chezmoi.os "linux"` の linuxbrew shellenv を削除。
  - `dot_zshenv.tmpl`: 同様に linuxbrew の PATH 行を削除。
  - `.chezmoitemplates/path-setup.tmpl`: 同様に linuxbrew の PATH 行を削除。
- `dot_zshrc.tmpl` の `lookPath "brew"` ベースの mysql-client パス設定はそのまま（Linux に brew が無くなれば自然にスキップされる構造のため）。
- Linux 側のランタイム検証は実機なしのため未実施。CI の `task check` で chezmoi template の展開エラーが出ないことのみ確認する想定。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->