### PR TITLE
chore: Claude Code のモデルを Opus 4.8 に更新

### DIFF
--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -200,7 +200,8 @@ local autoModeRules = import 'auto-mode.libsonnet';
   // model: 'claude-opus-4-1-20250805',
   // model: 'claude-opus-4-6',
   // model: 'claude-opus-4-6[1m]',
-  model: 'claude-opus-4-7[1m]',
+  // model: 'claude-opus-4-7[1m]',
+  model: 'claude-opus-4-8[1m]',
   // model: 'opus',
 
   // 無効らしい


### PR DESCRIPTION
## Why

Opus 4.8 が 2026-05-28 にリリースされたため、Claude Code のデフォルトモデルを 4.7 → 4.8 に追従する。1M context 版 (`[1m]`) を継続利用。

## What

- `dot_claude/settings.jsonnet` の `model` を `claude-opus-4-7[1m]` → `claude-opus-4-8[1m]` に変更
- 旧設定はコメントとして残し、ロールバック可能にした

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->