### PR TITLE
chore: Claude Code を 2.1.154 → 2.1.153 にダウングレード

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -102,7 +102,7 @@ go = "1.26.3"
 # ============================================
 # npm グローバルパッケージ
 # ============================================
-"aqua:anthropics/claude-code" = "2.1.154"
+"aqua:anthropics/claude-code" = "2.1.153"
 "aqua:google.com/antigravity-cli" = "1.0.3-6260531212976128" # agy: Gemini CLI の後継
 "aqua:openai/codex" = "0.135.0"
 "npm:ccusage" = "20.0.5"

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -61,26 +61,26 @@ checksum = "sha256:fae140432a4d18261a3640f85a23f6fa687cdbff983e6e05ed8b5ab5d0715
 url = "https://github.com/anthropics/anthropic-cli/releases/download/v1.9.3/ant_1.9.3_windows_amd64.zip"
 
 [[tools."aqua:anthropics/claude-code"]]
-version = "2.1.154"
+version = "2.1.153"
 backend = "aqua:anthropics/claude-code"
 
 [tools."aqua:anthropics/claude-code"."platforms.linux-arm64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/linux-arm64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.153/linux-arm64/claude"
 
 [tools."aqua:anthropics/claude-code"."platforms.linux-arm64-musl"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/linux-arm64-musl/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.153/linux-arm64-musl/claude"
 
 [tools."aqua:anthropics/claude-code"."platforms.linux-x64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/linux-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.153/linux-x64/claude"
 
 [tools."aqua:anthropics/claude-code"."platforms.linux-x64-musl"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/linux-x64-musl/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.153/linux-x64-musl/claude"
 
 [tools."aqua:anthropics/claude-code"."platforms.macos-arm64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/darwin-arm64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.153/darwin-arm64/claude"
 
 [tools."aqua:anthropics/claude-code"."platforms.macos-x64"]
-url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.154/darwin-x64/claude"
+url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.153/darwin-x64/claude"
 
 [[tools."aqua:arl/gitmux"]]
 version = "0.11.5"


### PR DESCRIPTION
## Why

#669 でアップデートした Claude Code 2.1.154 で、Opus 4.8 + interleaved thinking + parallel/background tool の組み合わせによりセッションが落ちる問題を踏んだ。

- [anthropics/claude-code#63463](https://github.com/anthropics/claude-code/issues/63463)
- [anthropics/claude-code#63393](https://github.com/anthropics/claude-code/issues/63393)
  - 400 `thinking blocks cannot be modified` で session 終了

v2.1.156 で fix がリリースノートに載っているが、[issue #63393 のコメント](https://github.com/anthropics/claude-code/issues/63393#issuecomment-4569373884) に「2.1.156 でも再現」報告があるため、Opus 4.8 リリース前 (2026-05-28 00:52 UTC) の安定版 v2.1.153 に戻す。

## What

- `dot_config/mise/config.toml`: `aqua:anthropics/claude-code` を `2.1.154` → `2.1.153`
- mise.lock は CI ワークフロー (`lockfiles-and-checksums.yaml`) で自動更新される

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->