### PR TITLE
fix: install.sh で mise trust を追加

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,11 @@ trap 'rm -rf "$TMP_BIN_DIR"' EXIT INT TERM
 ln -s "$MISE_BOOTSTRAP" "$TMP_BIN_DIR/mise"
 MISE="$TMP_BIN_DIR/mise"
 
+# 非対話実行でも config を読み込めるよう、ルート .mise.toml を信頼する。
+# trust が無いと mise は untrusted-config エラーで停止するか config をスキップし、
+# tools（chezmoi 含む）が install されない。明示パスで trust して path 解決を確実にする。
+"$MISE" trust "$(pwd)/.mise.toml"
+
 # ルート .mise.toml の tools を install（chezmoi 含む）
 "$MISE" install
 


### PR DESCRIPTION
## Why

`install.sh` で bootstrap した mise を使う際、ルート `.mise.toml` が trust されていないため、非対話の自動実行で `mise install` / `mise exec` が untrusted-config エラーで停止するか config をスキップしてしまう。結果として tools（chezmoi 含む）が install されず、初回セットアップが完走しない。

## What

- `mise install` の前に `"$MISE" trust "$(pwd)/.mise.toml"` を追加
- install.sh は冒頭でリポジトリルートへ `cd` 済み（`cd "$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"`）のため、`$(pwd)/.mise.toml` で path 解決を確実にし、明示パスで trust する
- これにより非対話・自動実行でも tools が読み込まれ、chezmoi の init/apply まで完走する

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->