### PR TITLE
feat: gwc に GWC_PNPM_EXTRA_DIRS を追加

### DIFF
--- a/dot_zsh/functions/git-worktree.zsh
+++ b/dot_zsh/functions/git-worktree.zsh
@@ -95,6 +95,7 @@ gwr() {
 #   gwc --pr 123 --copy data.json    # PR と追加ファイルを指定
 #   gwc --cursor                     # 作成後に Cursor で開く
 #   export GWC_COPY_FILES=".env.test,config.local.json"  # 環境変数で事前設定
+#   export GWC_PNPM_EXTRA_DIRS="apps/foo,apps/bar"  # root 以外で pnpm install するディレクトリ（worktree root からの相対パス、カンマ区切り）
 #
 gwc() {
     # 元のディレクトリを保存
@@ -368,6 +369,26 @@ gwc() {
             if command -v direnv >/dev/null 2>&1 && [ -f ".envrc" ]; then direnv allow .; fi
             if command -v pnpm >/dev/null 2>&1 && { [ -f "$worktree_path/pnpm-lock.yaml" ] || [ -f "package.json" ]; }; then pnpm install --frozen-lockfile; fi
         }
+
+        # 環境変数 GWC_PNPM_EXTRA_DIRS で指定された root 以外のディレクトリでも pnpm install を実行
+        # （pnpm workspace が分離しているモノレポなどで、root の挙動を変えずに追加で install したい場合用）
+        if [ -n "$GWC_PNPM_EXTRA_DIRS" ] && command -v pnpm >/dev/null 2>&1; then
+            local pnpm_extra_dirs=()
+            IFS=',' read -r -A pnpm_extra_dirs <<< "$GWC_PNPM_EXTRA_DIRS"
+            for extra_dir in "${pnpm_extra_dirs[@]}"; do
+                # 前後の空白を除去（"apps/foo, apps/bar" のようなコンマ後スペースに対応）
+                extra_dir="${extra_dir#"${extra_dir%%[^[:space:]]*}"}"
+                extra_dir="${extra_dir%"${extra_dir##*[^[:space:]]}"}"
+                [ -z "$extra_dir" ] && continue
+                local install_dir="${worktree_path}/${extra_dir}"
+                if [ -f "${install_dir}/pnpm-lock.yaml" ]; then
+                    echo "  ${extra_dir} で pnpm install を実行中..."
+                    (cd "$install_dir" && pnpm install --frozen-lockfile)
+                else
+                    echo "  警告: ${extra_dir} に pnpm-lock.yaml が見つかりません。スキップします。" >&2
+                fi
+            done
+        fi
 
         # --cursor フラグが指定されていた場合、Cursor で開く
         if $open_with_cursor; then


### PR DESCRIPTION
## Why

`gwc` は worktree 作成後に root で `pnpm install --frozen-lockfile` を実行するが、root の pnpm workspace に統合されていない（=別 lockfile を持つ）ディレクトリは install されない。pnpm workspace が分離しているモノレポなどで、root 以外のディレクトリも併せて install したいケースがある。

## What

環境変数 `GWC_PNPM_EXTRA_DIRS` を追加。

- worktree root からの相対パスをカンマ区切りで指定（例: `export GWC_PNPM_EXTRA_DIRS="apps/foo,apps/bar"`）
- 各ディレクトリに `pnpm-lock.yaml` があれば `pnpm install --frozen-lockfile` を実行、無ければ警告してスキップ
- root の install 挙動は変更なし。あくまで任意の追加 install
- 各 install はサブシェル `(cd ...)` で実行するため、cwd（着地先）は従来どおり worktree に着地
- コンマ後のスペース（`"apps/foo, apps/bar"`）も前後の空白除去で吸収

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->