### PR TITLE
fix: chpwd の ls を AIエージェント(非対話シェル)では抑制

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -69,8 +69,9 @@ if command -v nvim &> /dev/null; then
   alias view="nvim -R"
 fi
 
-# ディレクトリ移動時にls
+# ディレクトリ移動時にls（手動の対話シェル + 実tty出力時のみ。AIエージェント等では抑制）
 chpwd() {
+    [[ -o interactive && -t 1 ]] || return
     if [[ $(pwd) != $HOME ]]; then;
         ls -la
     fi


### PR DESCRIPTION
## Why

`cd` のたびに `chpwd()` が `ls -la` を出力するが、Claude Code や Codex などの AI エージェントが実行する `cd` でも出力され、エージェントの出力が冗長になっていた。手動操作時のみ `ls` を出したい。

実測の結果、AI エージェントの bash は**非対話シェル**（`interactive: no` / `stdout-tty: no`）で動作していることを確認。手動ターミナルのプロンプトとは判別可能。

## What

`chpwd()` に `[[ -o interactive && -t 1 ]] || return` ガードを追加。

| ケース | interactive | tty(fd1) | ls |
|---|---|---|---|
| 手動ターミナルのプロンプト | yes | yes | 出る（従来どおり） |
| AI bash（非対話） | no | no | 抑制 |
| AI が `zsh -i` + パイプ実行 | yes | no | 抑制 |

- `interactive` で非対話の AI bash を、`-t 1` で「対話だが出力がパイプ」のエージェントをカバー
- env var の deny-list（`CLAUDECODE` 等）を列挙する方式より、今後のエージェント追加にも自動で対応

(by Claude Code)