### PR TITLE
chore: gwr . で cd しないよう変更 & temporal Claude プラグイン削除

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,13 +12,6 @@
       "version": "1.0.0",
       "source": "./claude-plugins/aws-knowledge",
       "category": "development"
-    },
-    {
-      "name": "temporal",
-      "description": "Temporal Docs MCP (kapa.ai hosted) for framework documentation",
-      "version": "1.0.0",
-      "source": "./claude-plugins/temporal",
-      "category": "development"
     }
   ]
 }

--- a/claude-plugins/temporal/.claude-plugin/plugin.json
+++ b/claude-plugins/temporal/.claude-plugin/plugin.json
@@ -1,5 +1,0 @@
-{
-  "name": "temporal",
-  "description": "Temporal Docs MCP (kapa.ai hosted) for framework documentation",
-  "author": { "name": "Temporal" }
-}

--- a/claude-plugins/temporal/.mcp.json
+++ b/claude-plugins/temporal/.mcp.json
@@ -1,6 +1,0 @@
-{
-  "temporal": {
-    "type": "http",
-    "url": "https://temporal.mcp.kapa.ai"
-  }
-}

--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -26,7 +26,6 @@ local autoModeRules = import 'auto-mode.libsonnet';
     // gopls-lsp は重いため一律有効化しない。必要なプロジェクトで個別に有効化する。
     // 'gopls-lsp@claude-plugins-official': true,
     'aws-knowledge@tak848-plugins': true,
-    'temporal@tak848-plugins': true,
     'codex@openai-codex': true,
   },
   statusLine: {
@@ -155,8 +154,6 @@ local autoModeRules = import 'auto-mode.libsonnet';
       // Devin MCP (直接定義 — プラグインでは env var 展開が未対応)
       'mcp__devin__ask_question',
       'mcp__devin__read_wiki_contents',
-      // Temporal Plugin (tak848-plugins)
-      'mcp__plugin_temporal_temporal__*',
       // AWS Knowledge Plugin (tak848-plugins)
       'mcp__plugin_aws-knowledge_aws-knowledge__aws___search_documentation',
       'mcp__plugin_aws-knowledge_aws-knowledge__aws___read_documentation',

--- a/dot_zsh/functions/git-worktree.zsh
+++ b/dot_zsh/functions/git-worktree.zsh
@@ -65,22 +65,22 @@ gwr() {
             echo "エラー: メインのワークツリーは削除できません。" >&2
             return 1
         fi
-        # 現在の worktree 内からは remove できないため、先にメインへ移動する
-        echo "Moving to main worktree: $main_root"
-        cd "$main_root" || return 1
+        # 現在の worktree 内からだと git が「自身を削除」とみなして失敗するため、
+        # git -C でメイン側から remove する。これによりシェルの cd は一切行わない。
         echo "Removing worktree: $current_root"
-        if ! git worktree remove "$current_root" 2>/dev/null; then
+        if ! git -C "$main_root" worktree remove "$current_root" 2>/dev/null; then
             echo "Remove failed (uncommitted changes etc.)."
             read -q "REPLY?--force? [y/N] "
             echo
             if [[ "$REPLY" =~ ^[Yy]$ ]]; then
-                git worktree remove --force "$current_root"
+                git -C "$main_root" worktree remove --force "$current_root" || return 1
             else
-                # 削除しなかったので、移動前にいた元の worktree へ戻す
-                echo "Skipped. Returning to: $current_root"
-                cd "$current_root"
+                echo "Skipped."
+                return
             fi
         fi
+        # 削除に成功すると今いるディレクトリは消えている。移動はしないので手動で cd すること。
+        echo "Removed. Current directory no longer exists; cd to another worktree manually (e.g. gwt)."
         return
     fi
 

--- a/run_onchange_after_50-claude-plugins.sh.tmpl
+++ b/run_onchange_after_50-claude-plugins.sh.tmpl
@@ -2,8 +2,6 @@
 # {{ include ".claude-plugin/marketplace.json" | sha256sum }}
 # {{ include "claude-plugins/aws-knowledge/.claude-plugin/plugin.json" | sha256sum }}
 # {{ include "claude-plugins/aws-knowledge/.mcp.json" | sha256sum }}
-# {{ include "claude-plugins/temporal/.claude-plugin/plugin.json" | sha256sum }}
-# {{ include "claude-plugins/temporal/.mcp.json" | sha256sum }}
 # プラグイン定義が変更された時に marketplace update + plugin install を実行する
 
 {{ template "path-setup.tmpl" . }}
@@ -15,6 +13,6 @@ fi
 
 echo "Claude Code プラグインを更新中..."
 claude plugin marketplace update tak848-plugins || echo "WARN: marketplace update failed" >&2
-for plugin in aws-knowledge temporal; do
+for plugin in aws-knowledge; do
     claude plugin install "${plugin}@tak848-plugins" || echo "WARN: plugin install failed: ${plugin}" >&2
 done


### PR DESCRIPTION
## 概要

2 つの独立した変更:

### 1. `gwr .` で勝手に cd しない

`gwr .`（今いる worktree を削除）時に、これまでは「内部からは remove できない」制約のためメイン worktree へ `cd` していた。これをやめ、`git -C "$main_root" worktree remove` でメイン側のコンテキストから削除することで、**シェルのディレクトリを一切移動しない**ようにした。

- git プロセスの cwd がメイン側になるため「自身を削除」と誤認されず remove が成功する
- 削除後は今いたディレクトリが消えるため、別 worktree へは手動で cd する旨を案内（`gwt` 等）

### 2. temporal Claude プラグインの削除

`claude-plugins/temporal`（kapa.ai hosted Temporal Docs MCP）を削除し、関連参照も除去:

- `claude-plugins/temporal/` ディレクトリ削除
- `.claude-plugin/marketplace.json` の temporal エントリ削除
- `dot_claude/settings.jsonnet` の `enabledPlugins` / 許可リスト (`mcp__plugin_temporal_temporal__*`) から削除
- `run_onchange_after_50-claude-plugins.sh.tmpl` の include ハッシュ・install ループから削除

#### スコープ外（意図的に残置）

- `modify_dot_claude.json` の `unset $mcpServers "temporal"` … ~/.claude.json から旧 temporal MCP を掃除する処理。残置が安全なため変更せず
- `dot_codex/modify_config.toml` の `[mcp_servers.temporal]` … Codex 用の別 MCP 設定。Claude プラグインとは無関係のためスコープ外

## 検証

- `jq empty .claude-plugin/marketplace.json` ✅
- `jsonnet dot_claude/settings.jsonnet` ✅
- claude plugin 関連の temporal 参照が残っていないことを grep で確認 ✅

(by Claude Code)
