### PR TITLE
chore: language 設定を一時的に無効化し CLAUDE.md で言語制御

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -2,7 +2,7 @@
 
 プロジェクト横断のユーザー指示です。
 
-## 言語（一時的な試行）
+## 言語
 
 Think in English, interact with the user in Japanese.
 

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -2,6 +2,12 @@
 
 プロジェクト横断のユーザー指示です。
 
+## 言語（一時的な試行）
+
+Think in English, interact with the user in Japanese.
+
+> ハーネスの `language` 強制（settings の `language: 'japanese'`）をやめ、指示ベースで言語を出し分ける試行。効果がなければ見直す。
+
 ## MCP の使用（必須）
 
 ### 検索・情報取得

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -6,8 +6,6 @@
 
 Think in English, interact with the user in Japanese.
 
-> ハーネスの `language` 強制（settings の `language: 'japanese'`）をやめ、指示ベースで言語を出し分ける試行。効果がなければ見直す。
-
 ## MCP の使用（必須）
 
 ### 検索・情報取得

--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -2,7 +2,9 @@ local permissionRules = import 'permission-rules.libsonnet';
 local autoModeRules = import 'auto-mode.libsonnet';
 
 {
-  language: 'japanese',
+  // 【一時的】language 強制が思考まで日本語化する不具合の回避（claude-code#62123, #63875）。
+  // 言語制御は CLAUDE.md の「言語」セクションに委譲。問題なければ削除/復帰を判断する。
+  // language: 'japanese',
   plansDirectory: '.claude/plans',
   teammateMode: 'tmux',
   includeCoAuthoredBy: false,


### PR DESCRIPTION
## Why

Claude Code の `language` 設定（`settings.json` の `language: "japanese"`）はハーネスレベルで応答言語を強制するが、これにより**思考（thinking）まで日本語化**され推論品質が落ちる・挙動が不安定になるという問題が報告されている。

- https://qiita.com/natume_nat/items/76fe608d570caebb4f4c
- https://github.com/anthropics/claude-code/issues/62123
- https://github.com/anthropics/claude-code/issues/63875

## What

**一時的な試行**として、ハーネスの言語強制をやめ、指示ベースで言語を出し分ける方針に変更。効果がなければ見直す。

- `dot_claude/settings.jsonnet`: `language: 'japanese'` をコメントアウト（生成される `settings.json` から `language` キーが消え、デフォルト挙動に戻る）。一時的である旨と背景を `//` コメントで明記
- `dot_claude/CLAUDE.md`: 「言語（一時的な試行）」セクションを追加し、`Think in English, interact with the user in Japanese.` を指示

反映は PR マージ後にターゲット環境で `chezmoi update`（`run_onchange_after_40-generate-jsonnet.sh.tmpl` が `~/.claude/settings.json` を再生成）。

(by Claude Code)