### PR TITLE
chore: ccusage/codex を mise から削除

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -109,7 +109,6 @@ go = "1.26.4"
 "github:google-antigravity/antigravity-cli" = "1.0.6"     # agy: Gemini CLI の後継
 "aqua:openai/codex" = "0.137.0"
 "npm:ccusage" = "20.0.6"
-"npm:@ccusage/codex" = "19.0.0"
 "npm:@typescript/native-preview" = "7.0.0-dev.20260606.1"
 "npm:cc-sdd" = "3.0.2"
 "npm:difit" = "5.0.2"

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -1291,10 +1291,6 @@ url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-darwin-x64.tar.gz"
 checksum = "sha256:edaca9bd58ec8e92037dac4e877d52f6b8f430b81c18b57e264b4e2fb111cd56"
 url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-win-x64.zip"
 
-[[tools."npm:@ccusage/codex"]]
-version = "19.0.0"
-backend = "npm:@ccusage/codex"
-
 [[tools."npm:@fission-ai/openspec"]]
 version = "1.4.1"
 backend = "npm:@fission-ai/openspec"


### PR DESCRIPTION
## Why

`@ccusage/codex` パッケージが消滅したため。

## What

- `dot_config/mise/config.toml` から `npm:@ccusage/codex` を削除

(by Claude Code)