### PR TITLE
feat: lcm の引数なしブランチ逆引き & repo 名をリポジトリ名に修正

### DIFF
--- a/dot_zsh/functions/cmux.zsh
+++ b/dot_zsh/functions/cmux.zsh
@@ -17,34 +17,50 @@ _cmux_rename_current_workspace() {
 # lcm (Linear-CMux): Linear URL/identifier から現在の cmux ワークスペース名を設定する。
 #
 # 使用例:
+#   lcm                                               # 引数なし: 現在のブランチ名から逆引き
 #   lcm ENG-123                                       # identifier を直接指定
+#   lcm eng-123                                       # 小文字でも可（大文字に正規化）
 #   lcm https://linear.app/acme/issue/ENG-123/...     # Linear URL を指定
 #
 # 設定される名前: <repo>[<identifier>] <title>（例: dotfiles[ENG-123] Hogehoge）
-#   - git リポジトリ内なら repo はワークツリールートの basename
+#   - git リポジトリ内なら repo はリポジトリ名（worktree のディレクトリ名ではない）
 #   - git リポジトリ外なら repo を省略して [<identifier>] <title> になる
 # cmux 環境でなければエラー。Linear 情報取得には GWC_LINEAR_API_KEY が必要。
 lcm() {
-    if [ -z "$1" ]; then
-        echo "使い方: lcm <Linear URL | identifier(例 ENG-123)>" >&2
-        return 1
-    fi
     if ! _cmux_available; then
         echo "エラー: lcm は cmux 環境でのみ使用できます。" >&2
         return 1
     fi
 
+    # 引数なしの場合は現在のブランチ名から Linear ticket を逆引きする。
+    # ブランチ名（例 tak848/eng-123-foo）の識別子抽出・大文字正規化は _linear_fetch_issue 側で行う。
+    local ref="$1"
+    if [ -z "$ref" ]; then
+        ref=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+        if [ -z "$ref" ] || [ "$ref" = "HEAD" ]; then
+            echo "エラー: 引数がなく、現在のブランチ名も取得できませんでした。" >&2
+            echo "使い方: lcm [Linear URL | identifier(例 ENG-123)]" >&2
+            return 1
+        fi
+        if ! echo "$ref" | grep -oiE '[A-Z][A-Z0-9]*-[0-9]+' >/dev/null; then
+            echo "エラー: 現在のブランチ '$ref' から Linear identifier を抽出できませんでした。" >&2
+            return 1
+        fi
+        echo "ブランチ '$ref' から Linear ticket を逆引きします。"
+    fi
+
     # Linear issue 情報を取得（_linear_fetch_issue は git-worktree.zsh で定義）
     local issue
-    issue=$(_linear_fetch_issue "$1") || return 1
+    issue=$(_linear_fetch_issue "$ref") || return 1
     local identifier title
     identifier=$(echo "$issue" | jq -r '.identifier')
     title=$(echo "$issue" | jq -r '.title')
 
-    # repo 名: git リポジトリ内ならワークツリールートの basename、そうでなければ省略
-    local repo_prefix="" root_dir
-    root_dir=$(git rev-parse --show-toplevel 2>/dev/null)
-    [ -n "$root_dir" ] && repo_prefix="$(basename "$root_dir")"
+    # repo 名: git リポジトリ内ならリポジトリ名（_git_repo_name）、そうでなければ省略
+    local repo_prefix=""
+    if git rev-parse --show-toplevel >/dev/null 2>&1; then
+        repo_prefix="$(_git_repo_name)"
+    fi
 
     local ws_title
     if [ -n "$repo_prefix" ]; then

--- a/dot_zsh/functions/git-worktree.zsh
+++ b/dot_zsh/functions/git-worktree.zsh
@@ -13,9 +13,11 @@ _linear_fetch_issue() {
         return 1
     fi
 
-    # URL でも identifier でも ENG-123 形式の identifier を抽出
+    # URL / identifier / ブランチ名のいずれからでも ENG-123 形式の identifier を抽出。
+    # 小文字（eng-123 や ブランチ名 tak/eng-123-foo）でも拾えるよう大文字小文字を無視し、
+    # Linear API が要求する大文字 identifier に正規化する。
     local identifier
-    identifier=$(echo "$ref" | grep -oE '[A-Z][A-Z0-9]*-[0-9]+' | head -n 1)
+    identifier=$(echo "$ref" | grep -oiE '[A-Z][A-Z0-9]*-[0-9]+' | head -n 1 | tr '[:lower:]' '[:upper:]')
     if [ -z "$identifier" ]; then
         echo "エラー: '$ref' から Linear の identifier (例 ENG-123) を抽出できませんでした。" >&2
         return 1
@@ -36,6 +38,21 @@ _linear_fetch_issue() {
         return 1
     fi
     echo "$resp" | jq -c '.data.issue'
+}
+
+# リポジトリ名（worktree のディレクトリ名ではなく本来のリポジトリ名）を返す。
+# origin のリモート URL から導出し、なければワークツリールートの basename にフォールバック。
+# 例: git@github.com:tak848/dotfiles.git / https://github.com/tak848/dotfiles.git → dotfiles
+_git_repo_name() {
+    local url
+    url=$(git remote get-url origin 2>/dev/null)
+    if [ -n "$url" ]; then
+        basename "${url%.git}"
+    else
+        local root
+        root=$(git rev-parse --show-toplevel 2>/dev/null)
+        [ -n "$root" ] && basename "$root"
+    fi
 }
 
 # Git worktree間の移動を楽に
@@ -360,7 +377,8 @@ gwc() {
         local pr_number pr_title
         pr_number=$(echo "$pr_info" | jq -r '.number')
         pr_title=$(echo "$pr_info" | jq -r '.title')
-        cmux_title="${project_name}[#${pr_number}] ${pr_title}"
+        # repo は worktree ディレクトリ名ではなくリポジトリ名
+        cmux_title="$(_git_repo_name)[#${pr_number}] ${pr_title}"
 
         echo "PR からブランチ '$pr_branch' を取得しました。"
 
@@ -395,8 +413,8 @@ gwc() {
             return 1
         fi
 
-        # cmux ワークスペース名用の文字列をセット
-        cmux_title="${project_name}[${linear_identifier}] ${linear_title}"
+        # cmux ワークスペース名用の文字列をセット（repo は worktree ディレクトリ名ではなくリポジトリ名）
+        cmux_title="$(_git_repo_name)[${linear_identifier}] ${linear_title}"
 
         echo "Linear チケット $linear_identifier のブランチ名: $linear_branch"
 


### PR DESCRIPTION
## Why

#703 で導入した cmux ワークスペース名設定について、実運用で 2 点の改善要望が出た。

1. `lcm` を毎回 identifier を打って実行するのが手間。worktree 内なら今いるブランチ名から ticket を逆引きできるはず。また `eng-123` のような小文字でも動いてほしい。
2. ワークスペース名の repo 部分が **worktree のディレクトリ名**（例 `dotfiles-feat-eng-123`）になって長い。本来の **リポジトリ名**（`dotfiles`）にしたい。

## What

### `lcm` 引数なしブランチ逆引き（`dot_zsh/functions/cmux.zsh`）
- `lcm`（引数なし）で現在のブランチ名（例 `tak848/eng-123-foo`）から Linear ticket を逆引きして名前を設定
- ブランチから identifier を抽出できない場合は親切なエラー（detached HEAD も考慮）

### 小文字 identifier の許容（`_linear_fetch_issue`）
- identifier 抽出を大文字小文字無視（`grep -oiE`）にし、Linear API が要求する大文字へ正規化（`tr`）
- `lcm eng-123` でも、ブランチ名の小文字 identifier でも動作

### repo 名をリポジトリ名に修正（`_git_repo_name` を新設）
- origin のリモート URL から本来のリポジトリ名を導出（`git@github.com:tak848/dotfiles.git` / `https://.../dotfiles.git` → `dotfiles`）。リモートが無ければワークツリールートの basename にフォールバック
- `lcm` と `gwc`（Linear/PR モード）の cmux 名の両方でこれを使用。worktree ディレクトリ名（`project_name`）は従来どおりディレクトリ命名にのみ使用

### 検証
- `zsh -n` 構文チェック OK
- `_git_repo_name` → `dotfiles` を確認
- identifier 正規化（`eng-123` / `tak848/eng-123-foo` / URL → `ENG-123`、非該当は空）を確認
- `lcm` の 引数あり（小文字）/ 引数なし ticket 無しブランチ（エラー）/ 引数なし ticket 付きブランチ（逆引き成功）の 3 経路をモックで確認

(by Claude Code)