### PR TITLE
chore: メインモデルを fable-5 に変更し language 設定を復帰

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -2,10 +2,6 @@
 
 プロジェクト横断のユーザー指示です。
 
-## 言語
-
-Think in English, interact with the user in Japanese.
-
 ## MCP の使用（必須）
 
 ### 検索・情報取得

--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -2,9 +2,7 @@ local permissionRules = import 'permission-rules.libsonnet';
 local autoModeRules = import 'auto-mode.libsonnet';
 
 {
-  // 【一時的】language 強制が思考まで日本語化する不具合の回避（claude-code#62123, #63875）。
-  // 言語制御は CLAUDE.md の「言語」セクションに委譲。問題なければ削除/復帰を判断する。
-  // language: 'japanese',
+  language: 'japanese',
   plansDirectory: '.claude/plans',
   teammateMode: 'tmux',
   includeCoAuthoredBy: false,
@@ -200,7 +198,8 @@ local autoModeRules = import 'auto-mode.libsonnet';
   // model: 'claude-opus-4-6',
   // model: 'claude-opus-4-6[1m]',
   // model: 'claude-opus-4-7[1m]',
-  model: 'claude-opus-4-8[1m]',
+  // model: 'claude-opus-4-8[1m]',
+  model: 'claude-fable-5',
   // model: 'opus',
 
   // 無効らしい


### PR DESCRIPTION
## Why

メインモデルを Opus 4.8 から Fable 5 (`claude-fable-5`) に切り替える。

あわせて #699 で一時的に無効化していた `language: 'japanese'` 設定を復帰する。#699 は Opus で language 強制が思考まで日本語化し推論品質が落ちる問題への一時回避だったが、Fable 5 への切り替えを機にハーネスの言語強制を元に戻し、Fable 5 の挙動をしばらく観察する方針とする。

## What

- `dot_claude/settings.jsonnet`
  - `model` を `claude-opus-4-8[1m]` → `claude-fable-5` に変更（旧モデルはコメントとして残置）
  - 一時無効化していた `language: 'japanese'` を復帰（#699 の暫定コメントも削除）
- `dot_claude/CLAUDE.md`
  - #699 で追加した「言語」セクション（`Think in English, interact with the user in Japanese.`）を削除。language 強制に戻すため指示ベースの言語制御は不要

反映は PR マージ後にターゲット環境で `chezmoi update`（`run_onchange_after_40-generate-jsonnet.sh.tmpl` が `~/.claude/settings.json` を再生成）。

(by Claude Code)