### PR TITLE
feat: gwr . 完了後に cmux workspace を確認なしで自動クローズ

### DIFF
--- a/dot_zsh/functions/cmux.zsh
+++ b/dot_zsh/functions/cmux.zsh
@@ -14,6 +14,13 @@ _cmux_rename_current_workspace() {
     cmux workspace rename "$CMUX_WORKSPACE_ID" --title "$title"
 }
 
+# 「コマンドを実行している」cmux ワークスペースを閉じる。
+# socket API 直叩きのため GUI の確認ダイアログは出ない。実行元シェルごと終了する。
+# 呼び出し側で _cmux_available を確認してから呼ぶこと。
+_cmux_close_current_workspace() {
+    cmux workspace close "$CMUX_WORKSPACE_ID"
+}
+
 # lcm (Linear-CMux): Linear URL/identifier から現在の cmux ワークスペース名を設定する。
 #
 # 使用例:

--- a/dot_zsh/functions/git-worktree.zsh
+++ b/dot_zsh/functions/git-worktree.zsh
@@ -136,7 +136,13 @@ gwr() {
                 return
             fi
         fi
-        # 削除に成功すると今いるディレクトリは消えている。移動はしないので手動で cd すること。
+        # 削除に成功すると今いるディレクトリは消えている。
+        # cmux 環境なら全処理完了後に実行元ワークスペースを確認なしで閉じる（シェルも終了する）。
+        if _cmux_available; then
+            echo "Removed. Closing cmux workspace..."
+            _cmux_close_current_workspace
+            return
+        fi
         echo "Removed. Current directory no longer exists; cd to another worktree manually (e.g. gwt)."
         return
     fi


### PR DESCRIPTION
## Why

cmux 環境で `gwr .`（今いる worktree の削除）を実行した後、不要になった cmux workspace を手で閉じる必要があり、その際に確認を挟むのが手間だったため。

## What

- `cmux.zsh` に `_cmux_close_current_workspace()` を追加
  - `cmux workspace close "$CMUX_WORKSPACE_ID"` で実行元 workspace を閉じる
  - socket API 直叩きのため GUI の確認ダイアログは出ない
- `gwr .` で worktree 削除がすべて成功した後、cmux 環境（`_cmux_available`）であれば実行元 workspace を自動で閉じるようにした
  - 削除をスキップ・失敗した場合は閉じない（全処理完了後のみ）
  - 非 cmux 環境では従来どおりのメッセージ表示のみ

(by Claude Code)
