### PR TITLE
Revert "chore: メインモデルを fable-5 に変更し language 設定を復帰"

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -2,6 +2,10 @@
 
 プロジェクト横断のユーザー指示です。
 
+## 言語
+
+Think in English, interact with the user in Japanese.
+
 ## MCP の使用（必須）
 
 ### 検索・情報取得

--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -2,7 +2,9 @@ local permissionRules = import 'permission-rules.libsonnet';
 local autoModeRules = import 'auto-mode.libsonnet';
 
 {
-  language: 'japanese',
+  // 【一時的】language 強制が思考まで日本語化する不具合の回避（claude-code#62123, #63875）。
+  // 言語制御は CLAUDE.md の「言語」セクションに委譲。問題なければ削除/復帰を判断する。
+  // language: 'japanese',
   plansDirectory: '.claude/plans',
   teammateMode: 'tmux',
   includeCoAuthoredBy: false,
@@ -198,8 +200,7 @@ local autoModeRules = import 'auto-mode.libsonnet';
   // model: 'claude-opus-4-6',
   // model: 'claude-opus-4-6[1m]',
   // model: 'claude-opus-4-7[1m]',
-  // model: 'claude-opus-4-8[1m]',
-  model: 'claude-fable-5',
+  model: 'claude-opus-4-8[1m]',
   // model: 'opus',
 
   // 無効らしい


### PR DESCRIPTION
Reverts tak848/dotfiles#708

https://www.anthropic.com/news/fable-mythos-access
はやくもどして...
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->