### PR TITLE
chore: mise の cosign 回帰修正済みに伴い aqua cosign=false を撤去

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -7,11 +7,6 @@ lockfile = true
 # checksum があるツール（aqua: 等）は lockfile=true で検証される
 locked = false
 
-[settings.aqua]
-# mise v2026.3.6 の native cosign verification が CI 上で Rekor key parse に失敗するため、
-# dotfiles 用の aqua backend では checksum verification のみに寄せる
-cosign = false
-
 [env]
 # aube (mise の npm backend が内部で使う) の trustPolicy=no-downgrade が
 # tinyexec@1.2.2 を ERR_AUBE_TRUST_DOWNGRADE で拒否するため、


### PR DESCRIPTION
## Why

`dot_config/mise/config.toml` の `[settings.aqua] cosign = false` は、**mise v2026.3.6** で aqua backend の native cosign verification が CI 上で Rekor public key の parse に失敗する回帰バグ（Ed25519 の trust-root key を ECDSA P-256 として parse して落ちる）を回避するための一時的ワークアラウンドだった。

- 当該バグは **mise v2026.3.8 で修正済み**。メンテナが `aqua.cosign = false` のワークアラウンドは削除してよいと明言している（[jdx/mise#8547](https://github.com/jdx/mise/discussions/8547)）。v2026.5.1 で aqua の cosign metadata の扱いがさらに改善。
- 本リポジトリは現在 `v2026.6.5` をピンしており、修正版より十分新しい。
- 現状の lockfile は `provenance = "github-attestations"` のみで、汚染された `provenance = "cosign"` エントリは存在しない（cosign 無効化により回帰時も汚染が記録されなかった）。手動掃除は不要。

## What

- `dot_config/mise/config.toml` から `[settings.aqua]` ブロック（`cosign = false` とコメント）を削除し、mise デフォルト（`cosign = true`）に戻す。
- これにより aqua tools の cosign 署名検証が復活する。
- mise.lock / aqua-checksums の再生成は `lockfiles-and-checksums.yaml` ワークフローに委譲（このブランチへ自動 commit される想定）。

(by Claude Code)
