### PR TITLE
fix: gwr . で cmux workspace close 前に main worktree へ cd

### DIFF
--- a/dot_zsh/functions/git-worktree.zsh
+++ b/dot_zsh/functions/git-worktree.zsh
@@ -140,6 +140,9 @@ gwr() {
         # cmux 環境なら全処理完了後に実行元ワークスペースを確認なしで閉じる（シェルも終了する）。
         if _cmux_available; then
             echo "Removed. Closing cmux workspace..."
+            # cwd が削除済みディレクトリのままだと cmux バイナリが cwd を解決できず
+            # close に失敗するため、存在するメイン worktree へ移動してから閉じる。
+            cd "$main_root"
             _cmux_close_current_workspace
             return
         fi


### PR DESCRIPTION
## Why

`gwr .`（現在の worktree を削除）に cmux ワークスペースの自動 close を組み込んだが、実際には閉じられていなかった。

原因: `gwr .` は `git -C "$main_root" worktree remove "$current_root"` で**今いるディレクトリ自身を削除**する設計（シェルの cd は一切行わない）。削除直後はシェルの cwd が存在しないディレクトリになる。その状態で `cmux workspace close` を実行すると、`cmux` バイナリが起動時に自分の cwd を解決できず（getcwd / uv_cwd エラー）に失敗し、ワークスペースが閉じられていなかった。

## What

close を呼ぶ前に、必ず存在するメイン worktree (`$main_root`) へ `cd` して cwd を有効化する。`CMUX_WORKSPACE_ID` 環境変数で対象を特定しているため、cwd を変えても close 対象は変わらない。

- `dot_zsh/functions/git-worktree.zsh`: `gwr .` の cmux 分岐に `cd "$main_root"` を 1 行追加

スコープはこの cmux 分岐のみ。非 cmux 経路のメッセージ・挙動は変更なし。

(by Claude Code)