### PR TITLE
feat: mise global に Grok Build CLI (xAI) を追加

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -103,6 +103,7 @@ go = "1.26.4"
 "aqua:anthropics/claude-code" = "2.1.177"
 "github:google-antigravity/antigravity-cli" = "1.0.8"     # agy: Gemini CLI の後継
 "aqua:openai/codex" = "0.139.0"
+"aqua:x.ai/cli/grok" = "0.2.51" # Grok Build CLI (xAI のターミナル向けコーディングエージェント)
 "npm:ccusage" = "20.0.11"
 "npm:@typescript/native-preview" = "7.0.0-dev.20260612.1"
 "npm:cc-sdd" = "3.0.2"

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -979,6 +979,31 @@ url = "https://github.com/x-motemen/ghq/releases/download/v1.10.1/ghq_darwin_amd
 checksum = "sha256:a526da44d5f67250598fa95e5654815e9f672b2c05d1d98c28bce0e60d3cfa6c"
 url = "https://github.com/x-motemen/ghq/releases/download/v1.10.1/ghq_windows_amd64.zip"
 
+[[tools."aqua:x.ai/cli/grok"]]
+version = "0.2.51"
+backend = "aqua:x.ai/cli/grok"
+
+[tools."aqua:x.ai/cli/grok"."platforms.linux-arm64"]
+url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-aarch64"
+
+[tools."aqua:x.ai/cli/grok"."platforms.linux-arm64-musl"]
+url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-aarch64"
+
+[tools."aqua:x.ai/cli/grok"."platforms.linux-x64"]
+url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-x86_64"
+
+[tools."aqua:x.ai/cli/grok"."platforms.linux-x64-musl"]
+url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-x86_64"
+
+[tools."aqua:x.ai/cli/grok"."platforms.macos-arm64"]
+url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-macos-aarch64"
+
+[tools."aqua:x.ai/cli/grok"."platforms.macos-x64"]
+url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-macos-x86_64"
+
+[tools."aqua:x.ai/cli/grok"."platforms.windows-x64"]
+url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-windows-x86_64.exe"
+
 [[tools."github:aquaproj/aqua"]]
 version = "2.60.0"
 backend = "github:aquaproj/aqua"


### PR DESCRIPTION
## Why

[xAI の Grok Build changelog](https://x.ai/build/changelog) で公開されているターミナル向けコーディングエージェント Grok Build CLI を mise global で管理したい。

## What

- `dot_config/mise/config.toml` に `"aqua:x.ai/cli/grok" = "0.2.51"` を追加（AI コーディングエージェント群、`aqua:openai/codex` の隣）
- backend 選定:
  - mise 同梱レジストリには未登録（`mise registry grok` は not found）だが、[aqua-registry に `x.ai/cli/grok`](https://github.com/aquaproj/aqua-registry/blob/main/pkgs/x.ai/cli/grok/registry.yaml) が存在（`type: http` / `format: raw`、GCS の単一バイナリ `grok-{{.Version}}-{{.OS}}-{{.Arch}}` を指す）
  - レジストリ定義経由なので URL 手書き不要・Renovate (aqua) での自動更新・`lockfile=true` での checksum 検証に乗る
- 検証（隔離した `MISE_DATA_DIR` 環境）:
  - `aqua:x.ai/cli/grok@0.2.51` のインストール成功
  - `grok --version` → `grok 0.2.51 (f4f85a6492e)`
  - 4 プラットフォーム (macos/linux × arm64/x64) の成果物 URL がいずれも HTTP 200

## Note

- mise.lock / aqua-checksums は `lockfiles-and-checksums.yaml` ワークフローに委ねる（push 後に自動 commit）
- aqua-registry 定義の副バイナリ `agent` は raw 配布に同梱されておらず `bin path does not exist` 警告が出るが、`grok` 本体の動作には影響なし
- 利用には別途 `grok login` もしくは `GROK_DEPLOYMENT_KEY` による認証が必要（SuperGrok / X Premium+ の early beta）
