### PR TITLE
[codex] preserve Codex hook trust state

### DIFF
--- a/dot_codex/modify_config.toml
+++ b/dot_codex/modify_config.toml
@@ -110,4 +110,11 @@ model_reasoning_effort = "xhigh"
 
 {{ dict "notice" (index $existing "notice") | toToml -}}
 {{-   end }}
+{{-   if hasKey $existing "hooks" }}
+{{-     $hooks := index $existing "hooks" }}
+{{-     if hasKey $hooks "state" }}
+
+{{ dict "hooks" (dict "state" (index $hooks "state")) | toToml -}}
+{{-     end }}
+{{-   end }}
 {{- end }}


### PR DESCRIPTION
## Why

Codex stores trusted hook hashes in `~/.codex/config.toml` under `[hooks.state]`. The current chezmoi modify template preserved selected local sections such as `projects` and `notice`, but dropped `hooks.state`, so `chezmoi apply` could make already-trusted hooks appear new or changed again.

## What

- Preserve existing `hooks.state` when rendering `dot_codex/modify_config.toml`.
- Keep the change scoped to Codex config rendering; the hook definition and `ccgate codex` command are unchanged.
- Validation: `git diff --check -- dot_codex/modify_config.toml`; `chezmoi --source . diff -- /Users/takuya.takahashi.001/.codex/config.toml` confirmed the hook trust state is emitted in the rendered config.

(by Codex)