### PR TITLE
fix: resolve aqua http package lookups

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,6 +28,18 @@
       ],
     },
   ],
+  customDatasources: {
+    "1password-cli": {
+      defaultRegistryUrlTemplate: "https://app-updates.agilebits.com/check/1/0/CLI2/en/2.0.0/N",
+      transformTemplates: [
+        '{"releases":[{"version":$join(["v", version]),"changelogUrl":relnotes}],"homepage":"https://www.1password.dev/cli/"}',
+      ],
+    },
+    "grok-build": {
+      defaultRegistryUrlTemplate: "https://x.ai/cli/stable",
+      format: "plain",
+    },
+  },
   packageRules: [
     {
       description: "Default: 24h minimum age for stability",
@@ -35,9 +47,18 @@
       minimumReleaseAge: "24 hours",
     },
     {
-      description: "Ignore aqua HTTP packages without Renovate-supported version sources",
-      matchPackageNames: ["1password/cli", "x.ai/cli/grok"],
-      enabled: false,
+      description: "1Password CLI: use official update check endpoint for aqua HTTP package",
+      matchPackageNames: ["1password/cli"],
+      overrideDatasource: "custom.1password-cli",
+      overridePackageName: "1password-cli",
+      versioning: "semver",
+    },
+    {
+      description: "Grok Build CLI: use official xAI stable channel for aqua HTTP package",
+      matchPackageNames: ["x.ai/cli/grok"],
+      overrideDatasource: "custom.grok-build",
+      overridePackageName: "grok-build",
+      versioning: "semver",
     },
     {
       // mise.lock の更新は CI 側の lockfiles-and-checksums.yaml ワークフローに任せる。

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,6 +35,11 @@
       minimumReleaseAge: "24 hours",
     },
     {
+      description: "Ignore aqua HTTP packages without Renovate-supported version sources",
+      matchPackageNames: ["1password/cli", "x.ai/cli/grok"],
+      enabled: false,
+    },
+    {
       // mise.lock の更新は CI 側の lockfiles-and-checksums.yaml ワークフローに任せる。
       // Mend Cloud の allowedEnv (BUN_*, GO*, GRADLE_OPTS, RUSTC_BOOTSTRAP, PNPM_WORKERS,
       // PNPM_MAX_WORKERS) と allowedCommands (git add --all / git reset / pwd) には


### PR DESCRIPTION
## Why

Renovate Dependency Dashboard（#5）で `1password/cli` と `x.ai/cli/grok` の lookup failure が出ているため。

Renovate の mise manager はこれらを依存として検出できますが、明示的な `aqua:` パッケージ名は Renovate 側で GitHub lookup として扱われます。一方、該当する aqua-registry の定義はいずれも `type: http` で、GitHub repository を持たないため lookup に失敗していました。

## What

既存の `aqua:` tool 宣言は維持したまま、Renovate の lookup 先だけを公式の更新元へ向けるようにしました。

- `1password/cli`: 1Password 公式 update check JSON endpoint を使用
- `x.ai/cli/grok`: xAI 公式 stable channel endpoint を使用

Refs #5