### PR TITLE
feat: git-credential-manager を mise github backend で追加

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -56,6 +56,9 @@ go = "1.26.4"
 "aqua:x-motemen/ghq" = "1.10.1"
 "aqua:jesseduffield/lazygit" = "0.62.2"
 "aqua:jesseduffield/lazydocker" = "0.25.2"
+# Git credential helper（.NET self-contained。tar.gz を全展開し本体+DLL を同居させる。
+# symbols 版を除外するため matching_regex で末尾を絞り、createdump 等は filter_bins で隠す）
+"github:git-ecosystem/git-credential-manager" = { version = "v2.8.0", matching_regex = '[0-9]\.tar\.gz$', filter_bins = "git-credential-manager" }
 
 # エディタ・ターミナル
 "aqua:neovim/neovim" = "0.12.3"

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -1090,6 +1090,43 @@ url = "https://github.com/jdx/aube/releases/download/v1.21.0/aube-v1.21.0-x86_64
 url_api = "https://api.github.com/repos/jdx/aube/releases/assets/446887788"
 provenance = "github-attestations"
 
+[[tools."github:git-ecosystem/git-credential-manager"]]
+version = "2.8.0"
+backend = "github:git-ecosystem/git-credential-manager"
+
+[tools."github:git-ecosystem/git-credential-manager".options]
+matching_regex = '[0-9]\.tar\.gz$'
+
+[tools."github:git-ecosystem/git-credential-manager"."platforms.linux-arm64"]
+checksum = "sha256:6e1782b351eec3399db43699ff4fe2a1bf576654310ee4580aa4867705c0bc08"
+url = "https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.8.0/gcm-linux-arm64-2.8.0.tar.gz"
+url_api = "https://api.github.com/repos/git-ecosystem/git-credential-manager/releases/assets/407398054"
+
+[tools."github:git-ecosystem/git-credential-manager"."platforms.linux-arm64-musl"]
+checksum = "sha256:6e1782b351eec3399db43699ff4fe2a1bf576654310ee4580aa4867705c0bc08"
+url = "https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.8.0/gcm-linux-arm64-2.8.0.tar.gz"
+url_api = "https://api.github.com/repos/git-ecosystem/git-credential-manager/releases/assets/407398054"
+
+[tools."github:git-ecosystem/git-credential-manager"."platforms.linux-x64"]
+checksum = "sha256:6040c849b428a4e5b78594fd4fd2819fc3ea4ca472c13580b65a486bef9df21d"
+url = "https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.8.0/gcm-linux-x64-2.8.0.tar.gz"
+url_api = "https://api.github.com/repos/git-ecosystem/git-credential-manager/releases/assets/407398005"
+
+[tools."github:git-ecosystem/git-credential-manager"."platforms.linux-x64-musl"]
+checksum = "sha256:6040c849b428a4e5b78594fd4fd2819fc3ea4ca472c13580b65a486bef9df21d"
+url = "https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.8.0/gcm-linux-x64-2.8.0.tar.gz"
+url_api = "https://api.github.com/repos/git-ecosystem/git-credential-manager/releases/assets/407398005"
+
+[tools."github:git-ecosystem/git-credential-manager"."platforms.macos-arm64"]
+checksum = "sha256:a61399385e861b8e6e896d04e528eebe1214e002edbb98373e5a458dee194d56"
+url = "https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.8.0/gcm-osx-arm64-2.8.0.tar.gz"
+url_api = "https://api.github.com/repos/git-ecosystem/git-credential-manager/releases/assets/407397928"
+
+[tools."github:git-ecosystem/git-credential-manager"."platforms.macos-x64"]
+checksum = "sha256:bba2b1a20198b2a1a69496a7cd81f4cb23f569fcc7d17751a8a93c071bb6a2b9"
+url = "https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.8.0/gcm-osx-x64-2.8.0.tar.gz"
+url_api = "https://api.github.com/repos/git-ecosystem/git-credential-manager/releases/assets/407397828"
+
 [[tools."github:google-antigravity/antigravity-cli"]]
 version = "1.0.8"
 backend = "github:google-antigravity/antigravity-cli"


### PR DESCRIPTION
## Why

Git の認証ヘルパーとして git-credential-manager (GCM) を導入する。Homebrew を使わず mise で宣言的に管理するため、`.pkg`（システム領域に書き込み・グローバル git config を自動書き換え）ではなく tar.gz を `github:` backend で取得する。

ubi backend は deprecated（mise 公式 docs で GitHub backend への移行を案内）のため、後継の `github:` backend を採用。provenance / checksum 検証もネイティブに乗る。

## What

`dot_config/mise/config.toml` に以下を追加:

```toml
"github:git-ecosystem/git-credential-manager" = { version = "v2.8.0", matching_regex = '[0-9]\.tar\.gz$', filter_bins = "git-credential-manager" }
```

GCM のリリース構成・mise の挙動を踏まえた設定意図:

- **`.NET` self-contained アプリ**: tar.gz の中身は単一バイナリではなく、本体ランチャ `git-credential-manager` + 約200個の `.dll` / `.dylib`（`libcoreclr.dylib` 等）。`github:` backend はアーカイブを全展開し、root に実行ファイルがあれば root を bin path とするため、本体と DLL が同居したまま PATH に乗る。
- **`matching_regex = '[0-9]\.tar\.gz$'`**: 各プラットフォームに `…<version>.tar.gz` と `…-symbols.tar.gz` が並ぶ。前者は末尾が「数字 + `.tar.gz`」、後者は `s` + `.tar.gz` なので、この正規表現で symbols 版を除外。`.pkg` / `.deb` も自然に除外される。`osx` タグは mise の asset_matcher が macOS として認識する（`asset_matcher.rs` で確認済み）。
- **`filter_bins = "git-credential-manager"`**: 同梱の `createdump` 等を PATH に露出させない。

### 補足

- git への helper 登録（`git-credential-manager configure`）は本 PR のスコープ外。
- Linux では `credential.credentialStore`（secretservice / gpg+pass 等）の設定が別途必要な場合がある（実行時設定でありバイナリ依存ではない）。
- mise.lock の更新は GitHub Actions ワークフローに委ねる。

(by Claude Code)