### PR TITLE
chore: Claude transcript 保持期間を延長して ccusage 過去分の消失を防ぐ

### DIFF
--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -6,6 +6,9 @@ local autoModeRules = import 'auto-mode.libsonnet';
   // 言語制御は CLAUDE.md の「言語」セクションに委譲。問題なければ削除/復帰を判断する。
   // language: 'japanese',
   plansDirectory: '.claude/plans',
+  // ccusage が読む ~/.claude/projects/**/*.jsonl の自動削除を実質無効化（デフォルト30日 → 10年）。
+  // 過去の利用量集計が日々消えないようにするため。0 は無効値なので大きい値を指定する。
+  cleanupPeriodDays: 3650,
   teammateMode: 'tmux',
   includeCoAuthoredBy: false,
   extraKnownMarketplaces: {


### PR DESCRIPTION
## Why

ccusage で過去の利用量集計が日々減っていく問題への対処。

ccusage は `~/.claude/projects/**/*.jsonl` を集計するだけのステートレスツール（自前 DB を持たない）。Claude Code は `cleanupPeriodDays`（デフォルト **30 日**）を超えた transcript を**起動時に自動削除**するため、読み元ログが消えて ccusage の過去分が減っていた。

- 実機確認: `~/.claude/projects` の最古 jsonl が約 57 日前で、それ以前は消滅済み。
- Codex 側（`~/.codex/sessions/**/*.jsonl`）は自動 retention が無く約 9 ヶ月前まで残存 → **減っていない**ため変更不要。

裏取り: `cleanupPeriodDays` のデフォルト 30 日・起動時削除・`0` は無効値（公式 settings ドキュメント）、ccusage のデータソース（ccusage.com guide）、Codex の cleanup 系は未実装（openai/codex の提案 issue）。

## What

- `dot_claude/settings.jsonnet` のトップレベルに `cleanupPeriodDays: 3650`（10 年）を追加し、Claude transcript の自動削除を実質無効化。
- `chezmoi apply` 時の run_onchange で `~/.claude/settings.json` に反映される。
- Codex 側は変更なし（元々消えない）。

注意: これは**今後**の自動削除を止める設定で、既に削除済みの過去ログは復元できない。

(by Claude Code)
