### PR TITLE
feat: Claude Code 用 gopls-lazy LSP plugin を追加

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,6 +12,13 @@
       "version": "1.0.0",
       "source": "./claude-plugins/aws-knowledge",
       "category": "development"
+    },
+    {
+      "name": "gopls-lazy",
+      "description": "gopls-lazy LSP server for Go (lazy workspace proxy for large monorepos)",
+      "version": "1.0.0",
+      "source": "./claude-plugins/gopls-lazy",
+      "category": "development"
     }
   ]
 }

--- a/claude-plugins/gopls-lazy/.claude-plugin/plugin.json
+++ b/claude-plugins/gopls-lazy/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "gopls-lazy",
+  "description": "gopls-lazy LSP server for Go (lazy workspace proxy for large monorepos)",
+  "author": { "name": "tak848" }
+}

--- a/claude-plugins/gopls-lazy/.lsp.json
+++ b/claude-plugins/gopls-lazy/.lsp.json
@@ -1,0 +1,8 @@
+{
+  "go": {
+    "command": "gopls-lazy",
+    "extensionToLanguage": {
+      ".go": "go"
+    }
+  }
+}

--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -30,6 +30,9 @@ local autoModeRules = import 'auto-mode.libsonnet';
     'context7@claude-plugins-official': true,
     // gopls-lsp は重いため一律有効化しない。必要なプロジェクトで個別に有効化する。
     // 'gopls-lsp@claude-plugins-official': true,
+    // gopls-lazy は大規模 Go モノレポ向けの軽量 LSP プロキシ（mise: github:sivchari/gopls-lazy）。
+    // 公式 gopls-lsp と同様、一律有効化せず必要なプロジェクトで個別に有効化する。
+    // 'gopls-lazy@tak848-plugins': true,
     'aws-knowledge@tak848-plugins': true,
     'codex@openai-codex': true,
   },

--- a/run_onchange_after_50-claude-plugins.sh.tmpl
+++ b/run_onchange_after_50-claude-plugins.sh.tmpl
@@ -2,7 +2,10 @@
 # {{ include ".claude-plugin/marketplace.json" | sha256sum }}
 # {{ include "claude-plugins/aws-knowledge/.claude-plugin/plugin.json" | sha256sum }}
 # {{ include "claude-plugins/aws-knowledge/.mcp.json" | sha256sum }}
+# {{ include "claude-plugins/gopls-lazy/.claude-plugin/plugin.json" | sha256sum }}
+# {{ include "claude-plugins/gopls-lazy/.lsp.json" | sha256sum }}
 # プラグイン定義が変更された時に marketplace update + plugin install を実行する
+# 注: gopls-lazy はデフォルト無効（必要なプロジェクトで個別有効化）のため install ループには含めない
 
 {{ template "path-setup.tmpl" . }}
 


### PR DESCRIPTION
## Why

Claude Code はネイティブで LSP をサポートしており（plugin の `.lsp.json` / `plugin.json` の `lspServers`）、gopls-lazy を Go の language server として組み込める。`settings.jsonnet` では公式 `gopls-lsp` が「重いため一律有効化しない」方針でコメントアウトされているが、gopls-lazy はまさにその重さ問題を解決する軽量 LSP プロキシのため、自前 plugin として用意しておく。

公式 `gopls-lsp` plugin は command を gopls-lazy に差し替えられないため、`tak848-plugins` マーケットプレイスに自前 plugin を追加する形をとる。

参考: [Claude Code Plugins reference — LSP servers](https://code.claude.com/docs/en/plugins-reference.md)

なお Codex CLI は現状ネイティブ LSP 非対応（[openai/codex#8745](https://github.com/openai/codex/issues/8745) で開発中）のため、本 PR は Claude Code のみを対象とする。

## What

- `claude-plugins/gopls-lazy/.claude-plugin/plugin.json`: plugin メタデータ
- `claude-plugins/gopls-lazy/.lsp.json`: `command: "gopls-lazy"` / `extensionToLanguage: {".go": "go"}` で Go の LSP として設定
  - gopls-lazy はサブコマンド無しで LSP 起動する gopls の drop-in のため `args` は付けない（`gopls` は PATH から自動検出）
- `.claude-plugin/marketplace.json`: `gopls-lazy` plugin を登録
- `dot_claude/settings.jsonnet`: `enabledPlugins` に `gopls-lazy@tak848-plugins` のエントリを**コメントアウトで**追加（公式 `gopls-lsp` と同様、デフォルト無効・必要なプロジェクトで個別有効化）
- `run_onchange_after_50-claude-plugins.sh.tmpl`: gopls-lazy plugin 定義を変更検知のハッシュに追加（デフォルト無効のため自動 install ループには含めない）

### 前提

gopls-lazy 本体のインストールは別 PR #745（mise github backend）に依存する。本 PR は plugin 設定のみで、LSP が動くには gopls-lazy が PATH 上に必要。

## 検証

- JSON 構文チェック（`jq empty`）: marketplace.json / plugin.json / .lsp.json すべて OK
- `jsonnet dot_claude/settings.jsonnet` レンダリング OK
- 実利用確認（任意・別マシン）: #745 マージ後 `chezmoi update` → `mise install` で gopls-lazy 導入 → 対象 Go プロジェクトで `enabledPlugins` に `'gopls-lazy@tak848-plugins': true` を追加し、`/plugin` で LSP が起動することを確認

https://claude.ai/code/session_0146oiwmSDmgf2nwqzpdeWcf