### PR TITLE
fix: run_onchange の PATH で mise shims を Homebrew より優先

### DIFF
--- a/.chezmoitemplates/path-setup.tmpl
+++ b/.chezmoitemplates/path-setup.tmpl
@@ -9,5 +9,8 @@ export PATH="/opt/homebrew/bin:$PATH"
 export PATH="/usr/local/bin:$PATH"
 {{-   end }}
 {{- end }}
+# mise 管理ツール（claude/node 等）を Homebrew 等より優先する。
+# これが無いと run_onchange 内で /opt/homebrew/bin の野良ツールが mise 版を追い越して呼ばれる。
+export PATH="${XDG_DATA_HOME}/mise/shims:$PATH"
 export PATH="${XDG_DATA_HOME}/aquaproj-aqua/bin:$PATH"
 export AQUA_GLOBAL_CONFIG="${AQUA_GLOBAL_CONFIG:-}:${XDG_CONFIG_HOME}/aquaproj-aqua/aqua.yaml"


### PR DESCRIPTION
## Why

`chezmoi update` の run_onchange（`run_onchange_after_50-claude-plugins.sh.tmpl` 等）で、`claude plugin marketplace update` / `install` が以下のクラッシュで失敗していた。

```
TypeError: Cannot read properties of undefined (reading 'prototype')
  at /opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js
Node.js v25.6.1
WARN: marketplace update failed / plugin install failed
```

原因は **PATH の優先順位**。run_onchange は `.zshenv` を読まないため `path-setup.tmpl` で独自に PATH を組むが、その中で `/opt/homebrew/bin` を**先頭に prepend** していた。対話シェルから継承した mise の install パスより homebrew が前に割り込むため、run_onchange 内でのみ `/opt/homebrew/bin/claude`（過去の npm 版 v1.0.24 の残骸）が mise 管理のネイティブ claude（v2.x）を追い越して呼ばれ、Homebrew node 25 でクラッシュしていた。対話シェルでは mise パスが先頭なので問題は出ず、挙動が食い違っていた。

## What

- `.chezmoitemplates/path-setup.tmpl` に `${XDG_DATA_HOME}/mise/shims` を Homebrew より前へ prepend
- これにより run_onchange でも mise 管理ツール（claude / node 等）が優先され、野良ツールに追い越されない
- 副次効果として、この template を `{{ template "path-setup.tmpl" . }}` で取り込む run_onchange 群（mise-install / aqua-install / packages / jsonnet / claude-plugins）の rendered 内容が変わるため、次回 `chezmoi update` でこれらが一度再実行される。結果、`claude plugin marketplace update` が mise のネイティブ claude で再実行され自力で復旧する。

## 補足（このPRの対象外・任意の環境掃除）

クラッシュ自体は本 PR だけで止まる（野良を呼ばなくなるため）が、以下は不要な残骸なので任意で掃除可能：

- 野良 npm 版 claude（brew formula ではなく homebrew-node の global npm。`brew uninstall` では消えない）:
  `rm /opt/homebrew/bin/claude && rm -rf /opt/homebrew/lib/node_modules/@anthropic-ai/claude-code`
- 孤児の Homebrew node 25（`brew leaves` に出る手動インストール・依存ゼロ）: `brew uninstall node`

いずれも環境変更のため本 PR には含めず、各マシンで任意実施。

## 検証

- 次回 `chezmoi update` で run_onchange が再実行され、`Claude Code プラグインを更新中...` の後にクラッシュが出ないこと
- run_onchange 内 `command -v claude` が mise の `~/.local/share/mise/installs/aqua-anthropics-claude-code/.../claude` に解決されること

https://claude.ai/code/session_0146oiwmSDmgf2nwqzpdeWcf