### PR TITLE
feat: gopls-lazy LSP に workspaceFolder を明示指定

### DIFF
--- a/claude-plugins/gopls-lazy/.lsp.json
+++ b/claude-plugins/gopls-lazy/.lsp.json
@@ -1,6 +1,7 @@
 {
   "go": {
     "command": "gopls-lazy",
+    "workspaceFolder": "${CLAUDE_PROJECT_DIR}",
     "extensionToLanguage": {
       ".go": "go"
     }


### PR DESCRIPTION
## Why

gopls-lazy を Claude Code の LSP plugin として有効化したところ、`documentSymbol`（構文ベース）は動くが、`hover` / `references` / `definition` / `workspaceSymbol` などセマンティック機能が以下で失敗する：

```
no package metadata for file .../deps.go
This file is within module ".", which is not included in your workspace.
```

原因はソースで確定済み。gopls-lazy は LSP `initialize` の `rootUri` / `workspaceFolders` から workspace root を取得し（`proxy.go` `patchInitialize`、cwd は見ない）、root が取れた時だけ `directoryFilters` を本来のモジュールへ広げる。root が空だと `directoryFilters: ["-**"]`（全除外）のままになり、開いたファイルが永遠に orphan module `.` 扱いになる。`documentSymbol` は orphan でも動くため、症状が「構文系のみ動く」になる。

Claude Code がリポジトリルートから起動していても、LSP クライアントが `initialize` に `rootUri`/`workspaceFolders` を載せていなければ gopls-lazy の root は空のまま（cwd 非依存）。

## What

- `claude-plugins/gopls-lazy/.lsp.json` の `go` サーバに `"workspaceFolder": "${CLAUDE_PROJECT_DIR}"` を追加
- Claude Code がサポートする変数展開 `${CLAUDE_PROJECT_DIR}`（プロジェクトルート）を使い、gopls-lazy に明示的に workspace root を渡す
- 単一の絶対パス固定ではなく変数展開なので、リポジトリをまたいでも機能する

## 検証（マージ前に確認したい）

注: `workspaceFolder` フィールドおよび `${CLAUDE_PROJECT_DIR}` 展開の挙動は Claude Code 公式ドキュメントに詳細が無い（フィールドの存在のみ記載）。そのため要実測。

1. `GOPLS_LAZY_LOG` を一時的に有効化し、`initialize: root=<path>` のログ行で root が go.mod のあるルートに埋まることを確認
2. `.go` ファイルで hover / go-to-definition / find-references が動くことを確認

確認できたら merge。`${CLAUDE_PROJECT_DIR}` が `workspaceFolder` で展開されない場合は別手段（env / 起動方法）を検討する。

https://claude.ai/code/session_0146oiwmSDmgf2nwqzpdeWcf