### PR TITLE
feat: pup の zsh completion を追加

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -101,6 +101,11 @@ if command -v temporal &> /dev/null; then
   eval "$(temporal completion zsh)"
 fi
 
+# pup completion (遅延ロード)
+if command -v pup &> /dev/null; then
+  eval "$(pup completions zsh)"
+fi
+
 # fbr - checkout git branch (including remote branches), sorted by most recent commit, limit 30 last branches
 fbr() {
   local branches branch


### PR DESCRIPTION
## Why

- 先の PR で導入した `DataDog/pup` も zsh 補完を持っているため有効化したい

## What

- `dot_zshrc.tmpl`: `pup completions zsh` の遅延ロードを `task` / `mise` / `temporal` と同様の形式で追加
  - pup は clap_complete ベースで、補完出力サブコマンドは `completions`（複数形）
