### PR TITLE
chore: improve codex planning defaults

### DIFF
--- a/dot_codex/modify_config.toml
+++ b/dot_codex/modify_config.toml
@@ -147,6 +147,17 @@ model_reasoning_effort = "xhigh"
 
 {{ dict "notice" (index $existing "notice") | toToml -}}
 {{-   end }}
+{{-   if hasKey $existing "tui" }}
+{{-     $tui := index $existing "tui" }}
+{{-     if hasKey $tui "model_availability_nux" }}
+{{-       $modelAvailabilityNux := index $tui "model_availability_nux" }}
+
+[tui.model_availability_nux]
+{{-       range $model, $value := $modelAvailabilityNux }}
+{{ printf "%q = %v" $model $value }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
 {{-   if hasKey $existing "hooks" }}
 {{-     $hooks := index $existing "hooks" }}
 {{-     if hasKey $hooks "state" }}

--- a/dot_codex/modify_config.toml
+++ b/dot_codex/modify_config.toml
@@ -4,8 +4,8 @@
 model = "gpt-5.5"
 model_context_window = 1000000
 model_auto_compact_token_limit = 500000
-model_reasoning_effort = "high"
-plan_mode_reasoning_effort = "high"
+model_reasoning_effort = "xhigh"
+plan_mode_reasoning_effort = "xhigh"
 sandbox_mode = "workspace-write"
 approval_policy = "untrusted"
 personality = "pragmatic"
@@ -15,6 +15,8 @@ notify = ["{{ .chezmoi.homeDir }}/.codex/bin/notification"]
 developer_instructions = """\
 文脈を読め。指示の字面ではなく意図を汲め。ユーザーが求める粒度・スコープに合わせろ。\n\
 まず広く調べて地図を作れ。局所解に飛びつくな。\n\
+非自明な作業では、実装前に関連コード・設定・呼び出し元・CI・依存・スキーマ/API・既存ルールを横断調査し、調査済み根拠・未確認事項・判断が割れる点・影響範囲・検証条件・スコープ外を plan に明記しろ。\n\
+調査不足や判断不足のまま plan を確定するな。分からないことを埋めず、必要なら具体的な判断点としてユーザーに聞け。\n\
 設定・呼び出し元・CI・依存・影響範囲を横断で確認しろ。レビューでやる横断確認を、調査・plan・実装でもやれ。\n\
 1点直して終わるな。その変更がどこに波及するか見ろ。\n\
 設定変更・バージョン更新では、その値がどこで使われているかを先に全て洗い出せ。\n\


### PR DESCRIPTION
## Why

Codex で大きめの機能や issue を 1 session で「調査 → 計画 → 実装 → 検証 → Draft PR」まで進める場合、最初の plan の質がそのまま後続作業の進行方向を決める。ここで関連コード、設定、スキーマ/API、CI、既存ルール、未確認事項が plan に残らないと、長時間実行の途中で誤った前提が増幅し、実装後に大きな手戻りになる。

今回の調査で分かったことは、Codex の `/plan` は実装前の計画導線として提供されているものの、現時点では「重い planning artifact」として扱うには利用側の補助が必要という点。具体的には、Claude Code の `plansDirectory` のような plan artifact 保存先、TUI の `/plan` そのものに対する schema enforcement、調査済み根拠や未確認事項を必須化する built-in plan contract は確認できなかった。

そのため、現状のままでは「長く走れる」ことと「正しい方向に走る」ことが分離しやすい。長時間実行自体は便利でも、初期 plan が浅い場合は、schema/API の見落とし、既存 rule 違反、CI・生成物・呼び出し元の未確認、曖昧な仕様判断の放置が後段で発覚しやすい。今回の変更は、そのリスクを少しでも下げるため、Codex の reasoning effort を上げ、非自明な作業では plan に調査済み根拠・未確認事項・判断点・影響範囲・検証条件・スコープ外を残すよう user config 側で圧力を上げるもの。

これは Codex の planning workflow を完成させる変更ではない。deep planning prompt、plan Markdown artifact、Linear/Slack/GitHub 連携を含む planning-run workflow は別途作る必要がある。この PR は、まず日常の Codex セッションで「浅い plan のまま実装に入る」確率を下げるための最小設定変更として扱う。

### 調査結果

- Codex `/plan` は「実装前に execution plan を提案する」slash command として説明されている。一方で、plan をファイルに保存する built-in directory や、plan を編集可能 artifact として扱う設定は確認できなかった。
- Codex config には `plan_mode_reasoning_effort` と `developer_instructions` があり、今回の変更対象にできる。ただし、これらは plan の出力 schema を保証するものではなく、planning behavior を補助する設定に留まる。
- Codex の `--output-schema` は `codex exec` の非対話最終出力を JSON Schema で縛る機能。TUI の interactive `/plan` に直接 schema enforcement を掛ける仕組みではない。
- Codex best practices では、繰り返し使う作業パターンは `AGENTS.md` だけに詰め込まず、必要に応じて task-specific markdown や custom prompts に分ける運用が示されている。つまり、深い planning workflow は `AGENTS.md` 直書きではなく、別 prompt / 別 artifact に逃がすのが自然。
- OpenAI/codex issue #23481 では、Plan Mode は「編集を止めて plan を出すだけ」では不十分で、repo facts を先に調査し、discoverable facts と user preference を分け、重要な未決事項を質問し、decision-complete な plan を出すべきという課題が整理されている。今回の instruction 追加は、この方向に寄せるための最小対応。
- OpenAI/codex discussion #7355 では、planning/spec mode に対して、prescribed workflow と flexible workflow、modal/non-modal、plan artifact の扱いなどが議論されている。Codex 側では柔軟性を重視する方向が示されており、強い固定 workflow は利用者側の custom prompt / artifact 運用で補う必要がある。
- Sora Android の Codex 事例では、Codex に即実装させず、先に関連ファイルを読ませて理解を要約し、人間が誤解を修正し、mini design document 的な implementation plan を作り、必要に応じて plan file を保存してから実装に入っている。大きな作業では plan を外部化して確認する運用が実例として示されている。
- Codex が自動で書き込む TUI の model availability NUX state は runtime state であり、chezmoi modify template が保持しないと apply のたびに失われ、同じ案内が再表示される。今回の変更では、この state も保持対象に追加する。

### 参考リンク

- Codex `/plan`: https://developers.openai.com/codex/cli/slash-commands  
  `/plan` が実装前に execution plan を提案するための slash command であることの根拠。
- Codex config reference: https://developers.openai.com/codex/config-reference  
  `plan_mode_reasoning_effort` や `developer_instructions` など、今回変更する config key の根拠。
- Codex non-interactive structured outputs: https://developers.openai.com/codex/noninteractive  
  `--output-schema` が非対話実行の最終出力向けであり、TUI `/plan` の schema enforcement とは別であることの根拠。
- Codex best practices: https://developers.openai.com/codex/learn/best-practices  
  reusable guidance は `AGENTS.md`、task-specific markdown、custom prompts に分ける判断の根拠。
- Codex custom prompts: https://developers.openai.com/codex/custom-prompts  
  次の段階で deep planning prompt を作る場合の置き場所と呼び出し方の根拠。
- OpenAI/codex issue #23481: https://github.com/openai/codex/issues/23481  
  Plan Mode が repo facts の探索、未確認判断点の切り分け、decision-complete plan をより強く行うべきという課題提起。
- OpenAI/codex discussion #7355: https://github.com/openai/codex/discussions/7355  
  plan/spec mode の設計論点、特に workflow の強制度、modal/non-modal、artifact 化の議論。
- Sora Android planning case study: https://openai.com/index/shipping-sora-for-android-with-codex/  
  大きな作業で、関連ファイル理解、誤解修正、mini design document 的 plan、plan file 保存を挟んでから実装する運用例。

## What

- Codex の通常 reasoning effort と plan mode reasoning effort を `xhigh` に変更
- 非自明な作業の plan で、調査済み根拠、未確認事項、判断が割れる点、影響範囲、検証条件、スコープ外を明記するよう developer instructions を強化
- `tui.model_availability_nux` を既存 config から保持し、Codex が管理する model availability NUX state を chezmoi apply で消さないように変更
- deep planning prompt や plan artifact 運用の追加は別 PR に分離

## Validation

- `git diff --check -- dot_codex/modify_config.toml`
- `codex --strict-config -c 'model_reasoning_effort="xhigh"' -c 'plan_mode_reasoning_effort="xhigh"' --help`
- `chezmoi --source . --dry-run --verbose apply /Users/takuya.takahashi.001/.codex/config.toml` で対象 config のレンダリング差分を確認

Note: full `chezmoi --source . --dry-run --verbose apply` は、既存の `~/.config/mise/mise.lock` ローカル状態差分に対する TTY 確認で停止したため、対象 config の dry-run で確認した。
