### PR TITLE
docs: enforce repository PR conventions for codex

### DIFF
--- a/dot_codex/AGENTS.md
+++ b/dot_codex/AGENTS.md
@@ -42,6 +42,8 @@ Always respond in 日本語(japanese).
 
 ## PR・issue ルール
 
+- **最重要**: PR title / branch name / commit message / PR description / issue body は、必ず対象リポジトリの規約・テンプレート・既存の書き方に従うこと。`[codex]` や `codex/` などの agent 名 prefix を勝手に付けてはならない。
+- PR description や issue body は、対象リポジトリのテンプレートや既存構成を尊重すること。指示されていない独自の見出し構成・要約形式・agent 由来の定型文へ勝手に置き換えないこと。
 - PR 作成時はリポジトリ内の PULL REQUEST テンプレートを探索し（ルート、`.github/`、`docs/`、各 `PULL_REQUEST_TEMPLATE/` サブディレクトリ）、見つかったら必ず従うこと。テンプレートを無視した PR は禁止
 - issue/PR にコメント・返信する際は、本文末尾に `(by Codex)` を付与すること
 - レビューコメントの指摘に対して修正を行った場合は、必ず該当コメントに reply すること。修正した commit へのリンク（`https://github.com/{owner}/{repo}/commit/{sha}` 形式）を含めること


### PR DESCRIPTION
## Why

GitHub publish skill などの既定挙動で、対象リポジトリの規約にない agent prefix や独自の PR description 構成が入ることを防ぐため。

共通 Codex 指示で、PR title / branch name / commit message / PR description / issue body は対象リポジトリの規約・テンプレート・既存の書き方を最優先することを明示します。

## What

- `dot_codex/AGENTS.md` の PR・issue ルールに最重要項目を追加
- `[codex]` や `codex/` などの agent 名 prefix を勝手に付けることを禁止
- PR description / issue body を独自構成へ勝手に置き換えないことを明記

Validation:

- `git diff --check -- dot_codex/AGENTS.md`
- `chezmoi --source . --dry-run --verbose apply /Users/takuya.takahashi.001/.codex/AGENTS.md`
