### PR TITLE
fix(codex): use canonical hooks feature flag

### DIFF
--- a/dot_codex/modify_config.toml
+++ b/dot_codex/modify_config.toml
@@ -47,6 +47,7 @@ status_line = [
 ]
 
 [features]
+hooks = true
 unified_exec = true
 shell_snapshot = true
 prevent_idle_sleep = true


### PR DESCRIPTION
## Why

`[features].codex_hooks` is deprecated. Use the canonical `[features].hooks` key to avoid the Codex startup deprecation warning.

## What

- Add `hooks = true` under `[features]` in `dot_codex/modify_config.toml`.
- Confirm the generated Codex config emits `hooks = true` and does not emit `codex_hooks`.
- Validation: `rg -n "codex_hooks|hooks\s*=\s*true|\[features\]" dot_codex AGENTS.md`
- Validation: `chezmoi --source . --dry-run --verbose apply`
- Validation: `chezmoi --source . cat ~/.codex/config.toml | rg -n "codex_hooks|hooks\s*=\s*true|\[features\]"`