### PR TITLE
chore: auto-memory を無効化しグローバル運用ルールを追加

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -77,3 +77,14 @@ Think in English, interact with the user in Japanese.
 
 - 自動許可: `git switch`, `git restore`, `git commit`（amend除く）
 - 禁止: `--amend`, `--no-gpg-sign`, `reset --hard`
+
+## メモリ（auto-memory）を使わない
+
+Claude Code の auto-memory（`~/.claude/projects/<project>/memory/`）は設定で無効化済み。使わない。学び・規約・コンテキストは memory に溜めず、内容に応じて置き場所を振り分ける:
+
+- **プロジェクトに還元すべき規約・知見** → 各 Agent が追える位置に配置し、プロジェクトで git 管理する。Claude はそのプロジェクトの `CLAUDE.md`（リポジトリ直下／該当サブディレクトリ）、Codex はそのプロジェクトの `AGENTS.md`。
+- **複数人で共有する意味のないもの**（タスクの進め方・細かい運用ルール・個人の嗜好寄りの話）→ `CLAUDE.local.md` に追記する。git worktree の場合は worktree root の `CLAUDE.local.md` に書く。`CLAUDE.local.md` へ書く前に必ずユーザーに確認する。
+
+## 散文に不要な改行を入れない
+
+PR 本文・plan・issue/PR コメント・ドキュメント等の散文で、見栄え目的の改行（hard wrap）を入れない。改行は段落の区切り・リスト・コードブロックなど意味のある区切りにだけ使う。1文の途中で折り返さない。

--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -11,6 +11,10 @@ local autoModeRules = import 'auto-mode.libsonnet';
   cleanupPeriodDays: 3650,
   teammateMode: 'tmux',
   includeCoAuthoredBy: false,
+  // auto-memory を全プロジェクトで一律無効化。false で読み書き・memory ディレクトリ生成を停止する。
+  // 規約・コンテキストは CLAUDE.md / AGENTS.md / CLAUDE.local.md に集約する方針。
+  // ref: https://code.claude.com/docs/en/memory#enable-or-disable-auto-memory
+  autoMemoryEnabled: false,
   extraKnownMarketplaces: {
     'tak848-plugins': {
       source: {

--- a/dot_codex/AGENTS.md
+++ b/dot_codex/AGENTS.md
@@ -47,3 +47,7 @@ Always respond in 日本語(japanese).
 - PR 作成時はリポジトリ内の PULL REQUEST テンプレートを探索し（ルート、`.github/`、`docs/`、各 `PULL_REQUEST_TEMPLATE/` サブディレクトリ）、見つかったら必ず従うこと。テンプレートを無視した PR は禁止
 - issue/PR にコメント・返信する際は、本文末尾に `(by Codex)` を付与すること
 - レビューコメントの指摘に対して修正を行った場合は、必ず該当コメントに reply すること。修正した commit へのリンク（`https://github.com/{owner}/{repo}/commit/{sha}` 形式）を含めること
+
+## 散文に不要な改行を入れない
+
+PR 本文・plan・issue/PR コメント・ドキュメント等の散文で、見栄え目的の改行（hard wrap）を入れない。改行は段落の区切り・リスト・コードブロックなど意味のある区切りにだけ使う。1文の途中で折り返さない。


### PR DESCRIPTION
## Why

メモリにサイロ化した規約が原因で、Agent ごとに挙動が割れる事故が起きた（PR #725 で cross-agent 規約を集約済み）。メモリは全撲滅済みで read を残す意味がないため、auto-memory を設定でハード無効化し、情報が version-controlled なファイルへ向かう運用をグローバル指示に固定する。あわせて、散文に見栄え目的の改行（hard wrap）を入れる癖をやめるルールを足す。

## What

- `dot_claude/settings.jsonnet`: `autoMemoryEnabled: false` を追加。auto-memory の読み書き・memory ディレクトリ生成を全プロジェクトで停止する。
- `dot_claude/CLAUDE.md`: 2つのルールを追記。(1) メモリは使わず、プロジェクトに還元すべき規約は各 Agent が追える git 管理ファイル（Claude は `CLAUDE.md`、Codex は `AGENTS.md`）へ、共有不要な個人寄りの話は `CLAUDE.local.md`（worktree 時は worktree root、書く前にユーザー確認）へ振り分ける。(2) PR 本文・plan・コメント等の散文に hard wrap を入れない。
- `dot_codex/AGENTS.md`: 散文に hard wrap を入れないルールを追記（PR 本文は Codex も書くため）。auto-memory は Codex に無い機能なのでメモリ振り分けルールは入れない。

(by Claude Code)