### PR TITLE
feat: codex writable_roots に go/pkg/sumdb を追加

### DIFF
--- a/dot_codex/modify_config.toml
+++ b/dot_codex/modify_config.toml
@@ -58,6 +58,7 @@ network_access = true
 writable_roots = [
   "{{ .chezmoi.homeDir }}/.local/share/aquaproj-aqua",
   "{{ .chezmoi.homeDir }}/go/pkg/mod",
+  "{{ .chezmoi.homeDir }}/go/pkg/sumdb",
 {{- if eq .chezmoi.os "darwin" }}
   "{{ .chezmoi.homeDir }}/Library/Caches",
 {{- end }}


### PR DESCRIPTION
## Why

Go module 検証時の sumdb キャッシュ書き込みを Codex サンドボックスで許可するため。`go/pkg/mod` のみだと sumdb 関連の書き込みでブロックされるケースがある。

## What

- `dot_codex/modify_config.toml` の `sandbox_workspace_write.writable_roots` に `~/go/pkg/sumdb` を追加
