### PR TITLE
fix: commit-via-graphql の argv 長超過で lockfile commit が壊れる問題を修正

### DIFF
--- a/.github/scripts/commit-via-graphql.sh
+++ b/.github/scripts/commit-via-graphql.sh
@@ -25,6 +25,9 @@ set -euo pipefail
 REGENERATE_CMD="${REGENERATE_CMD:-}"
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
 
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
 attempt=0
 while :; do
   attempt=$((attempt + 1))
@@ -45,37 +48,45 @@ while :; do
 
   EXPECTED_OID=$(git rev-parse HEAD)
 
-  additions=$(
+  # ファイル内容は jq の argv に載せない。base64 化した lockfile は単一引数の
+  # 上限 (Linux の MAX_ARG_STRLEN = 128KB) を超え得て、--arg/--argjson が
+  # "Argument list too long" (E2BIG) で失敗する。--rawfile / --slurpfile で
+  # 一時ファイルから読ませ、GraphQL payload は gh に stdin (--input -) で渡す。
+  adds_file="$WORKDIR/additions.json"
+  input_file="$WORKDIR/input.json"
+  payload_file="$WORKDIR/payload.json"
+
+  {
     # shellcheck disable=SC2086
     for f in $FILES; do
-      jq -n \
-        --arg path "$f" \
-        --arg contents "$(base64 < "$f" | tr -d '\n')" \
+      b64="$WORKDIR/content.b64"
+      base64 < "$f" | tr -d '\n' >"$b64"
+      jq -n --arg path "$f" --rawfile contents "$b64" \
         '{path: $path, contents: $contents}'
-    done | jq -s '.'
-  )
+    done
+  } | jq -s '.' >"$adds_file"
 
-  input=$(jq -n \
+  jq -n \
     --arg repo "$REPO" \
     --arg branch "$BRANCH" \
     --arg oid "$EXPECTED_OID" \
     --arg msg "$MESSAGE" \
-    --argjson adds "$additions" \
+    --slurpfile adds "$adds_file" \
     '{
       branch: {repositoryNameWithOwner: $repo, branchName: $branch},
       expectedHeadOid: $oid,
       message: {headline: $msg},
-      fileChanges: {additions: $adds}
-    }')
+      fileChanges: {additions: $adds[0]}
+    }' >"$input_file"
 
-  payload=$(jq -n \
+  jq -n \
     --arg query 'mutation($input: CreateCommitOnBranchInput!) {
       createCommitOnBranch(input: $input) { commit { url oid } }
     }' \
-    --argjson input "$input" \
-    '{query: $query, variables: {input: $input}}')
+    --slurpfile input "$input_file" \
+    '{query: $query, variables: {input: $input[0]}}' >"$payload_file"
 
-  if echo "$payload" | gh api graphql --input -; then
+  if gh api graphql --input - <"$payload_file"; then
     exit 0
   fi
 


### PR DESCRIPTION
## Why

PR #774 / #775 / #754 で急に全 CI が落ち始めた（#769〜#772 は成功していた）。

lockfile 更新ワークフロー（`lockfiles-and-checksums.yaml`）が呼ぶ `.github/scripts/commit-via-graphql.sh` が、再生成した lockfile を GraphQL `createCommitOnBranch` で commit する際、各ファイルの base64 内容を **jq のコマンドライン引数**（`--argjson adds "$additions"`）として渡していた。lockfile の肥大化で、この単一引数が Linux の `MAX_ARG_STRLEN`（131072 bytes / 128KB）を超え、`jq: Argument list too long`（E2BIG）で失敗するようになった。

その結果、workflow の commit が `dot_config/mise/mise.lock` と `aqua-checksums.json` の更新を取りこぼし、ブランチの lockfile が古いバージョンを pin したまま残る。`config.toml` が新バージョンを要求するため CI の `mise install --locked` が `... is not in the lockfile` で失敗していた。

裏付け（`renovate/claude-code` ブランチ実測）:
- `dot_config/mise/mise.lock` の base64 だけで約 108KB、3 ファイル合算の `additions` JSON は約 133KB で 128KB 上限を超過
- 失敗ログ: `commit-via-graphql.sh: line 58: /usr/bin/jq: Argument list too long`

#769〜772 が通っていたのは、当時 lockfile がまだ 128KB 閾値未満だったため。

## What

- ファイル内容を jq の argv に載せない方式へ変更。各ファイルの base64 は `--rawfile` で一時ファイルから読み、`additions` / `input` は `--slurpfile` で読む。
- GraphQL payload は `gh api graphql --input -` に **stdin 経由**で渡し、argv を一切使わない。
- 一時ファイルは作業ディレクトリ（`mktemp -d`）にまとめ、`trap ... EXIT` で確実に削除。
- 共有スクリプトのため、`lockfiles-and-checksums` / `mise-bootstrap` / `lazy-lock` の 3 ワークフローすべてが一括で堅牢化される。

ローカル検証: 実際の肥大化した lockfile（約 134KB payload）で E2BIG が出ずに payload を生成でき、3 ファイルとも base64 roundtrip が元ファイルと一致することを確認済み。

> [!NOTE]
> workflow はブランチ checkout 内のスクリプトを実行するため、既に詰まっている renovate PR（#774 / #775 / #754）はこの fix を main にマージした後 **rebase** して初めて回復する。fix マージだけでは自動回復しない。

https://claude.ai/code/session_011Z5Hucr8ByWBMRmMJuZwgm