### PR TITLE
fix: plan mode で auto mode classifier の介入を止め ccgate に判定を戻す

### DIFF
--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -207,6 +207,12 @@ local autoModeRules = import 'auto-mode.libsonnet';
     allow: autoModeRules.allow,
     soft_deny: autoModeRules.soft_deny,
   },
+  // plan mode 中に auto mode classifier が read-only tool を auto-allow し、
+  // ccgate（PermissionRequest hook）をバイパスするのを止める。許可判定は ccgate に一本化する。
+  // auto mode 自体は無効化しない（disableAutoMode は使わない）。Shift+Tab での手動利用は維持。
+  // CC 2.1.186 で入った plan-mode read-only auto-allow 挙動への対処。
+  // 未設定（デフォルト）は true 扱い（cBr() の `!== false` 判定）のため、明示的に false にする必要がある。
+  useAutoModeDuringPlan: false,
   // model: 'claude-opus-4-1-20250805',
   // model: 'claude-opus-4-6',
   // model: 'claude-opus-4-6[1m]',


### PR DESCRIPTION
## Why

Claude Code `2.1.186` で「plan mode 中に read-only tool を auto mode classifier が auto-allow する」挙動が入り（`2.1.200` で調整）、`2.1.201` でも有効。この結果、**plan mode 中の tool 実行が ccgate（PermissionRequest hook）ではなく auto mode classifier によって処理される**（plan mode の Bash が "Allowed by auto mode classifier" で通ることを確認）。

許可制御を ccgate に一本化している運用では、`dot_claude/auto-mode.libsonnet` のコメント通り「Auto Mode 中は PermissionRequest hook が発火せず ccgate が呼ばれない」ため、plan mode で classifier が介入すると ccgate がバイパスされてしまう。

## What

`dot_claude/settings.jsonnet` トップレベルに `useAutoModeDuringPlan: false` を追加。

- claude 2.1.201 の実装上、plan mode の tool 評価は `cBr()`（`useAutoModeDuringPlan !== false` を全 settings source で満たすか）→ `Fgr()` → `$on()` を通る。`useAutoModeDuringPlan: false` にすると `$on()` が null を返し、**plan mode で auto mode classifier を使わず通常フロー（ccgate）に判定が戻る**。
- 未設定（デフォルト）は `!== false` が true に評価され classifier が介入するため、明示的に `false` にする必要がある。
- `permissions.defaultMode` は `'plan'` のまま（起動 mode は変更しない）。
- `permissions.disableAutoMode` は設定しない＝**auto mode 自体は無効化せず、`Shift+Tab` での手動利用は維持**。
- `dot_claude/auto-mode.libsonnet` は変更なし。

### 検証

- `jsonnet dot_claude/settings.jsonnet | jq '.useAutoModeDuringPlan'` → `false`（`.permissions.defaultMode` は `"plan"`、`.permissions.disableAutoMode` は未設定のまま）を確認済み。
- マージ→`chezmoi update` 後、新しい plan mode セッションで read-only tool の承認が "Allowed by auto mode classifier" ではなく ccgate 経由になること、`Shift+Tab` で auto mode に手動切替できることを確認予定。

https://claude.ai/code/session_01RDWcNynq6sYhvZgfPHgXbh