### PR TITLE
chore: 実験的 Agent Teams を無効化する

### DIFF
--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -9,7 +9,8 @@ local autoModeRules = import 'auto-mode.libsonnet';
   // ccusage が読む ~/.claude/projects/**/*.jsonl の自動削除を実質無効化（デフォルト30日 → 10年）。
   // 過去の利用量集計が日々消えないようにするため。0 は無効値なので大きい値を指定する。
   cleanupPeriodDays: 3650,
-  teammateMode: 'tmux',
+  // teammateMode は Agent Teams 用の設定。Agent Teams 無効化に伴い不要（下記 env 参照）。
+  // teammateMode: 'tmux',
   includeCoAuthoredBy: false,
   // auto-memory を全プロジェクトで一律無効化。false で読み書き・memory ディレクトリ生成を停止する。
   // 規約・コンテキストは CLAUDE.md / AGENTS.md / CLAUDE.local.md に集約する方針。
@@ -262,7 +263,11 @@ local autoModeRules = import 'auto-mode.libsonnet';
     DISABLE_ERROR_REPORTING: '1',
     DISABLE_NON_ESSENTIAL_MODEL_CALLS: '1',
     CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR: '1',
-    CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
+    // 実験的 Agent Teams は無効化する。teammate（subagent）の permission request が
+    // PermissionRequest hook を経由せず端末の手動プロンプトに直行し、ccgate による許可判定が
+    // バイパスされる既知バグ（anthropics/claude-code#23983, open）があるため。
+    // 許可制御を ccgate に一本化している運用と両立しない。upstream 修正後に再検討する。
+    // CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
   },
   effortLevel: 'xhigh',
   // alwaysThinkingEnabled は adaptive thinking (effortLevel) により不要


### PR DESCRIPTION
## Why

実験的 Agent Teams（`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`）を使うと、teammate（subagent）の permission request が **PermissionRequest hook を経由せず**端末の手動プロンプト（"Do you want to proceed?"）に直行し、**ccgate による許可判定がバイパスされる**。

これは Claude Code 本体の既知バグ [anthropics/claude-code#23983](https://github.com/anthropics/claude-code/issues/23983)（`bug` / `has repro` / `area:core`、open）。メインセッションの permission request では hook が発火する一方、Agent Teams の subagent では発火しない。実測でも、teammate が実行した read-only コマンドが ccgate ログに一切現れず手動プロンプトに落ちることを確認した。

許可制御を ccgate に一本化している運用と両立しないため、upstream 修正までは Agent Teams を無効化する。

## What

`dot_claude/settings.jsonnet` から Agent Teams 関連キーを無効化（コメントアウト）:

- `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1'` … 有効化スイッチ本体
- `teammateMode: 'tmux'` … Agent Teams 用の付随設定（teams 無効化に伴い不要）

理由コメントに #23983 を残し、upstream 修正後の再検討が分かるようにした。

無効化後は通常の Task subagent（ccgate が正常に発火する）に寄せる。`useAutoModeDuringPlan: false`（別 PR で追加済み）はそのまま維持。

### 検証

- `jsonnet dot_claude/settings.jsonnet | jq '{teammateMode, agentTeams: .env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS}'` → 両方 `null`（キー消滅）を確認済み。JSON 破損なし。
- マージ→`chezmoi update` 後、`~/.claude/settings.json` の `env` に `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` が無いこと、新規セッションで Agent Teams（teammate spawn）が起動しないことを確認予定。

## Related

- anthropics/claude-code#23983（本 PR の根拠となる open バグ）

https://claude.ai/code/session_01RDWcNynq6sYhvZgfPHgXbh