### PR TITLE
feat: Claude Code の TUI を fullscreen rendering に切り替える

### DIFF
--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -12,6 +12,11 @@ local autoModeRules = import 'auto-mode.libsonnet';
   // teammateMode は Agent Teams 用の設定。Agent Teams 無効化に伴い不要（下記 env 参照）。
   // teammateMode: 'tmux',
   includeCoAuthoredBy: false,
+  // fullscreen rendering（research preview）。classic renderer は再描画のたびに scrollback を
+  // 破壊する既知バグがあり、上スクロールで表示が崩れるため fullscreen に切り替える。
+  // 履歴検索は Ctrl+O（transcript mode）→ `[` で native scrollback に書き出して Cmd+F。
+  // ref: https://code.claude.com/docs/en/fullscreen
+  tui: 'fullscreen',
   // auto-memory を全プロジェクトで一律無効化。false で読み書き・memory ディレクトリ生成を停止する。
   // 規約・コンテキストは CLAUDE.md / AGENTS.md / CLAUDE.local.md に集約する方針。
   // ref: https://code.claude.com/docs/en/memory#enable-or-disable-auto-memory


### PR DESCRIPTION
## Why

Claude Code の classic renderer（デフォルト TUI）には、再描画のたびに `\e[3J`（Erase Saved Lines）を発行して terminal scrollback を破壊する既知の regression があり（v2.1.76 以降、最新 2.1.202 でも未修正）、ターミナルで上スクロールすると表示が崩れる。fullscreen rendering（research preview、[docs](https://code.claude.com/docs/en/fullscreen)）は alternate screen buffer 上でアプリ内スクロールを提供し、この崩れが発生しない。

## What

- `dot_claude/settings.jsonnet` に `tui: 'fullscreen'` を追加。`/tui fullscreen` がターゲットの `~/.claude/settings.json` に書き込む設定を jsonnet ソースへ反映し、`chezmoi apply`（jsonnet 全体生成）で消えないようにする
- 履歴の全文検索（Cmd+F）が必要な場合は `Ctrl+O`（transcript mode）→ `[` で native scrollback へ書き出せる旨をコメントに記載

(by Claude Code)