### PR TITLE
feat: fullscreen TUI のクリック選択無効化と verbose フル表示を設定する

### DIFF
--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -12,6 +12,9 @@ local autoModeRules = import 'auto-mode.libsonnet';
   // teammateMode は Agent Teams 用の設定。Agent Teams 無効化に伴い不要（下記 env 参照）。
   // teammateMode: 'tmux',
   includeCoAuthoredBy: false,
+  // ツール出力・コマンド出力を省略せずフル表示する。表示が省略されて情報が欠けるのを避ける。
+  // thinking の常時フル表示設定は存在しない（transcript viewer の Ctrl+E で全表示は可能）。
+  verbose: true,
   // fullscreen rendering（research preview）。classic renderer は再描画のたびに scrollback を
   // 破壊する既知バグがあり、上スクロールで表示が崩れるため fullscreen に切り替える。
   // 履歴検索は Ctrl+O（transcript mode）→ `[` で native scrollback に書き出して Cmd+F。

--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -261,6 +261,11 @@ local autoModeRules = import 'auto-mode.libsonnet';
     // MAX_THINKING_TOKENS: '31199',
     // CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: '1',  // これを設定すると MAX_THINKING_TOKENS に戻る
 
+    // fullscreen rendering のマウスクリック機能（select メニューのクリック選択・click-to-expand 等）
+    // を無効化する。ダイアログ表示直後の意図しないクリックで選択肢が勝手に確定する事故を防ぐ。
+    // ホイールスクロールは維持される（CLAUDE_CODE_DISABLE_MOUSE と違いキャプチャ自体は残る）。
+    // ref: https://code.claude.com/docs/en/fullscreen#keep-native-text-selection
+    CLAUDE_CODE_DISABLE_MOUSE_CLICKS: '1',
     CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY: '1',
     // DISABLE_TELEMETRY はフィーチャーフラグ(Statsig)の取得も停止してしまうため無効化
     // ref: https://zenn.dev/m0370/articles/d7e77adebd0ba8


### PR DESCRIPTION
## Why

#781 で fullscreen rendering に切り替えた結果、2 つの問題が残っている。①fullscreen はマウスをキャプチャし select メニューをクリックで選択できる（v2.1.187+）ため、ダイアログ表示直後の意図しないクリックで選択肢（AskUserQuestion・permission prompt 等）が勝手に確定する事故が起きる。②ツール出力・コマンド出力が省略表示され、情報が欠けて確認の手間が増える。

## What

- `env.CLAUDE_CODE_DISABLE_MOUSE_CLICKS: '1'` を追加（v2.1.195+、[docs](https://code.claude.com/docs/en/fullscreen#keep-native-text-selection)）。クリック・ドラッグ・ホバーのみ無効化し、ホイールスクロールは維持される
- `verbose: true` を追加し、ツール出力・コマンド出力を省略せずフル表示する。なお thinking を常時フル表示する設定は存在せず、transcript viewer（`Ctrl+O`）内の `Ctrl+E`（Toggle show all content）で代替する

(by Claude Code)