### PR TITLE
fix: 別端末で claude plugin marketplace が登録されず update に失敗する問題を修正

### DIFF
--- a/run_onchange_after_50-claude-plugins.sh.tmpl
+++ b/run_onchange_after_50-claude-plugins.sh.tmpl
@@ -15,7 +15,10 @@ if ! command -v claude &> /dev/null; then
 fi
 
 echo "Claude Code プラグインを更新中..."
-claude plugin marketplace update tak848-plugins || echo "WARN: marketplace update failed" >&2
+# settings.json の extraKnownMarketplaces 宣言だけでは、非対話 CLI 用の状態ファイル
+# （~/.claude/plugins/known_marketplaces.json）にマーケットプレイスが登録されない。
+# 明示的に add して登録する（同名は置換される冪等操作。最新を clone し直すため update は不要）。
+claude plugin marketplace add tak848/dotfiles || echo "WARN: marketplace add failed" >&2
 for plugin in aws-knowledge; do
     claude plugin install "${plugin}@tak848-plugins" || echo "WARN: plugin install failed: ${plugin}" >&2
 done


### PR DESCRIPTION
## Why

別端末で `chezmoi update` を実行すると、プラグインセットアップ段階で以下が失敗していた:

```
✘ Failed to update marketplace(s): Marketplace 'tak848-plugins' not found.
  Available marketplaces: claude-plugins-official, freee-api-marketplace
WARN: marketplace update failed
✘ Failed to install plugin "aws-knowledge@tak848-plugins": Plugin "aws-knowledge" not found in marketplace "tak848-plugins".
WARN: plugin install failed: aws-knowledge
```

根本原因: `run_onchange_after_50-claude-plugins.sh.tmpl` は `chezmoi apply` 時の非対話コンテキストで、いきなり `claude plugin marketplace update tak848-plugins` を実行していた。しかし `settings.json` の `extraKnownMarketplaces` は「マーケットプレイスの所在宣言」にすぎず、非対話 CLI 用の状態ファイル `~/.claude/plugins/known_marketplaces.json` には自動登録されない（対話セッション起動時の遅延クローン、または明示的な `marketplace add` が必要）。`update` / `install` は状態ファイルに登録済みのマーケットプレイスしか対象にできないため、未登録の新端末では `update` が "not found" で失敗し `install` も連鎖失敗していた。既存端末で動くのは過去の対話セッションが登録済みだったため。

（claude-code-guide エージェントで公式ドキュメント裏付け済み: `extraKnownMarketplaces` は状態を自動登録しない／`marketplace add` は同名を置換する冪等操作／`install` は marketplace が add 済みであることを要求。）

## What

- `run_onchange_after_50-claude-plugins.sh.tmpl` の `claude plugin marketplace update tak848-plugins` を `claude plugin marketplace add tak848/dotfiles` に置き換え。
  - `add` は状態ファイルへ明示登録する。同名マーケットプレイスは置換される冪等操作なので毎回実行して問題なく、かつ最新を clone し直すため後続の `update` は不要。
  - clone 範囲は現状維持の全体クローン（`--sparse` は使わない）。
- `settings.jsonnet` の `extraKnownMarketplaces` / `enabledPlugins` は対話セッションでのプラグイン有効化に引き続き必要なため変更なし。

### 検証

- ローカルはシェル構文チェックのみ（`bash -n`, syntax OK）。remote main が single source of truth のためローカル `chezmoi apply` 検証は不可。
- 実挙動はマージ後に marketplace 未登録の新端末で `chezmoi update` を実行し、`marketplace add` と `aws-knowledge@tak848-plugins` install が WARN なしで成功することを確認する。既存端末でも `add` が冪等に成功することを確認する。

https://claude.ai/code/session_017ieUPgxgTZuATLceGiDoZh