### PR TITLE
fix: Claude Code の TUI を default renderer に戻す

### DIFF
--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -15,11 +15,11 @@ local autoModeRules = import 'auto-mode.libsonnet';
   // ツール出力・コマンド出力を省略せずフル表示する。表示が省略されて情報が欠けるのを避ける。
   // thinking の常時フル表示設定は存在しない（transcript viewer の Ctrl+E で全表示は可能）。
   verbose: true,
-  // fullscreen rendering（research preview）。classic renderer は再描画のたびに scrollback を
-  // 破壊する既知バグがあり、上スクロールで表示が崩れるため fullscreen に切り替える。
-  // 履歴検索は Ctrl+O（transcript mode）→ `[` で native scrollback に書き出して Cmd+F。
+  // classic renderer（default）。かつて再描画のたびに scrollback を破壊するバグがあり
+  // fullscreen に切り替えていたが、2.1.204 時点で崩れが解消したことを確認したため戻す。
+  // fullscreen はマウスキャプチャにより素のドラッグで文字選択できない点がストレスだった。
   // ref: https://code.claude.com/docs/en/fullscreen
-  tui: 'fullscreen',
+  tui: 'default',
   // auto-memory を全プロジェクトで一律無効化。false で読み書き・memory ディレクトリ生成を停止する。
   // 規約・コンテキストは CLAUDE.md / AGENTS.md / CLAUDE.local.md に集約する方針。
   // ref: https://code.claude.com/docs/en/memory#enable-or-disable-auto-memory


### PR DESCRIPTION
## Why

classic renderer の scrollback 破壊（上スクロールで表示が崩れる）を避けるため #781 で fullscreen rendering に切り替えたが、fullscreen はマウスキャプチャにより素のドラッグで文字選択できず（Shift+ドラッグが必要）ストレスが大きい。v2.1.204 時点で classic renderer の表示崩れが解消したことをユーザーが実機確認したため戻す（changelog に該当修正の明記は無いが、実機挙動を優先する）。

## What

- `dot_claude/settings.jsonnet` の `tui` を `'fullscreen'` から `'default'` に変更し、コメントを経緯に合わせて更新
- `env.CLAUDE_CODE_DISABLE_MOUSE_CLICKS`（#783）は fullscreen 時のみ作用する設定のため残置（default では無害、再度 fullscreen に切り替えた場合の誤クリック防止として機能する）

(by Claude Code)