### PR TITLE
feat: gwc に --ccs (claude --model sonnet 起動) を追加

### DIFF
--- a/dot_zsh/functions/git-worktree.zsh
+++ b/dot_zsh/functions/git-worktree.zsh
@@ -205,6 +205,7 @@ gwr() {
 #   gwc ENG-123 --cc                 # 作成後に claude を初期プロンプトで起動（GWC_CLAUDE_CODE_INITIAL_PROMPT）
 #   gwc ENG-123 --ccf                # 作成後に claude --model fable を初期プロンプトで起動
 #   gwc ENG-123 --cco                # 作成後に claude --model opus を初期プロンプトで起動
+#   gwc ENG-123 --ccs                # 作成後に claude --model sonnet を初期プロンプトで起動
 #   gwc ENG-123 --co                 # 作成後に codex を初期プロンプトで起動（GWC_CODEX_CLI_INITIAL_PROMPT）
 #   gwc ENG-123 --cc "追加の指示"     # 初期プロンプト + 改行2つ + 追加プロンプトで起動（ref より後ろに置くこと）
 #   gwc ENG-123 --ccco               # cmux 限定: claude を現在ペイン、codex を右 split で同時起動
@@ -234,7 +235,7 @@ gwc() {
     local open_with_cursor=false
     local cmux_title=""  # cmux 環境ならワークスペース名に設定する文字列（Linear/PR モードでセット）
     local launch_agent=""  # --cc → claude / --co → codex / --ccco → claude（前面）。worktree 作成後に初期プロンプトで起動
-    local launch_model=""  # --ccf → fable / --cco → opus。claude 起動時だけ --model として渡す
+    local launch_model=""  # --ccf → fable / --cco → opus / --ccs → sonnet。claude 起動時だけ --model として渡す
     local split_agent=""   # --ccco → codex を右 split で起動（claude は launch_agent で現在ペイン前面起動）
     local agent_extra=""   # --cc / --co / --ccco の後ろに渡された追加プロンプト
 
@@ -296,7 +297,7 @@ gwc() {
             # 直後にオプションでないトークンがあれば追加プロンプトとして取り込む
             # （例: gwc ENG-123 --cc "追加の指示"）。ref と紛れないよう --cc/--co は ref の後ろに置くこと。
             if [ -n "$launch_agent" ] || [ -n "$split_agent" ]; then
-                echo "エラー: --cc / --co / --ccco は同時に指定できません。" >&2
+                echo "エラー: --cc / --ccf / --cco / --ccs / --co / --ccco は同時に指定できません。" >&2
                 return 1
             fi
             if [ "$1" = "--cc" ]; then
@@ -310,18 +311,20 @@ gwc() {
                 shift # 追加プロンプトを消費
             fi
             ;;
-        --ccf | --cco)
+        --ccf | --cco | --ccs)
             if [ -n "$launch_agent" ] || [ -n "$split_agent" ]; then
-                echo "エラー: --cc / --ccf / --cco / --co / --ccco は同時に指定できません。" >&2
+                echo "エラー: --cc / --ccf / --cco / --ccs / --co / --ccco は同時に指定できません。" >&2
                 return 1
             fi
             launch_agent="claude"
             if [ "$1" = "--ccf" ]; then
                 launch_model="fable"
-            else
+            elif [ "$1" = "--cco" ]; then
                 launch_model="opus"
+            else
+                launch_model="sonnet"
             fi
-            shift # --ccf / --cco を消費
+            shift # --ccf / --cco / --ccs を消費
             if [ -n "$1" ] && [[ "$1" != -* ]]; then
                 agent_extra="$1"
                 shift # 追加プロンプトを消費
@@ -331,7 +334,7 @@ gwc() {
             # cmux 限定: claude を現在ペイン前面、codex を右 split で同時起動する。
             # 末尾に非オプションのトークンがあれば両エージェント共通の追加プロンプトとして取り込む。
             if [ -n "$launch_agent" ] || [ -n "$split_agent" ]; then
-                echo "エラー: --cc / --co / --ccco は同時に指定できません。" >&2
+                echo "エラー: --cc / --ccf / --cco / --ccs / --co / --ccco は同時に指定できません。" >&2
                 return 1
             fi
             # validation を最初に: cmux 環境でなければここで弾く（worktree を作らない）


### PR DESCRIPTION
## Why

gwc に既存の `--ccf`(fable) / `--cco`(opus) と並ぶ形で、`--ccs`(sonnet) が欲しかったため。

## What

- `--ccs` オプションを追加。指定すると worktree 作成後に `claude --model sonnet` を初期プロンプト付きで起動する
- `--ccf` / `--cco` のオプション解析ブロックに `--ccs` を追加し、`launch_model` に `sonnet` を設定
- 排他チェックのエラーメッセージ・使用例コメントを更新