### PR TITLE
feat: add opencode to mise

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -85,6 +85,13 @@
       extractVersion: "^rust-v(?<version>.+)$",
     },
     {
+      description: "opencode: independent PR, no age gate",
+      matchPackageNames: ["anomalyco/opencode"],
+      matchManagers: ["mise"],
+      groupName: "opencode",
+      minimumReleaseAge: "0 hours",
+    },
+    {
       description: "ccgate: 自作ツールなので age gate なし",
       matchPackageNames: ["tak848/ccgate"],
       groupName: "ccgate",

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -109,6 +109,7 @@ go = "1.26.4"
 "aqua:anthropics/claude-code" = "2.1.204"
 "github:google-antigravity/antigravity-cli" = "1.0.16"     # agy: Gemini CLI の後継
 "aqua:openai/codex" = "0.143.0"
+"aqua:anomalyco/opencode" = "1.17.15"
 "aqua:x.ai/cli/grok" = "0.2.51" # Grok Build CLI (xAI のターミナル向けコーディングエージェント)
 "npm:ccusage" = "20.0.14"
 "npm:@typescript/native-preview" = "7.0.0-dev.20260706.1"

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -74,6 +74,45 @@ url = "https://github.com/DataDog/pup/releases/download/v1.6.2/pup_1.6.2_Darwin_
 url_api = "https://api.github.com/repos/DataDog/pup/releases/assets/464934796"
 provenance = "cosign"
 
+[[tools."aqua:anomalyco/opencode"]]
+version = "1.17.15"
+backend = "aqua:anomalyco/opencode"
+
+[tools."aqua:anomalyco/opencode"."platforms.linux-arm64"]
+checksum = "sha256:23aad358a8489cda9e9c46cde7ce87b2fc4847203ddb4d2179be34215ad6eeae"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.15/opencode-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/469281358"
+
+[tools."aqua:anomalyco/opencode"."platforms.linux-arm64-musl"]
+checksum = "sha256:ec753c4fcc2b5e2e6948f06c18c82c1160976a0cd85e7c6c7e911c35c82ebb5f"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.15/opencode-linux-arm64-musl.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/469281365"
+
+[tools."aqua:anomalyco/opencode"."platforms.linux-x64"]
+checksum = "sha256:0e1353771192c7d2dc0c610d61ff70668bb8a4420dc4d9e35cfd33d7245f3e67"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.15/opencode-linux-x64.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/469281439"
+
+[tools."aqua:anomalyco/opencode"."platforms.linux-x64-musl"]
+checksum = "sha256:782c5d6fc3762fbdfaebcebc7457ed797acbab199969b3b237acfac195fd09d8"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.15/opencode-linux-x64-musl.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/469281373"
+
+[tools."aqua:anomalyco/opencode"."platforms.macos-arm64"]
+checksum = "sha256:9667289c143d1fbdd440055af4041bb432f44b07ddf0aef048a8c7f2f7c65e2d"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.15/opencode-darwin-arm64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/469281295"
+
+[tools."aqua:anomalyco/opencode"."platforms.macos-x64"]
+checksum = "sha256:4bc40c124a1b419cfa922cadb3d68c2d67b2082276360b3ca36003aa350d9ad4"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.15/opencode-darwin-x64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/469281293"
+
+[tools."aqua:anomalyco/opencode"."platforms.windows-x64"]
+checksum = "sha256:4853d74160d639557db1ebde9d327c38fb95b1db0886afc18d9ef962459d84e2"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.17.15/opencode-windows-x64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/469284289"
+
 [[tools."aqua:anthropics/anthropic-cli"]]
 version = "1.16.0"
 backend = "aqua:anthropics/anthropic-cli"


### PR DESCRIPTION
## Why

opencode を mise の aqua backend で管理できるようにするため。

## What

- `dot_config/mise/config.toml` に `aqua:anomalyco/opencode` v1.17.15 を追加
- Renovate で opencode を個別 PR に分離し、24h age gate の例外に設定