### PR TITLE
chore: Codex のモデルを gpt-5.6-sol に固定

### DIFF
--- a/dot_codex/modify_config.toml
+++ b/dot_codex/modify_config.toml
@@ -1,7 +1,7 @@
 {{- /* chezmoi:modify-template */ -}}
 #:schema https://developers.openai.com/codex/config-schema.json
 
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_context_window = 1000000
 model_auto_compact_token_limit = 500000
 model_reasoning_effort = "xhigh"
@@ -121,11 +121,11 @@ tools.aws___get_regional_availability.approval_mode = "approve"
 tools.aws___retrieve_agent_sop.approval_mode = "approve"
 
 [profiles.fast]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 
 [profiles.xhigh]
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "xhigh"
 
 [profiles.codex]


### PR DESCRIPTION
## Why

Codex の固定モデルが `gpt-5.5` のままだったため、最新の `gpt-5.6-sol` に更新する。

## What

`dot_codex/modify_config.toml` の `gpt-5.5` 固定箇所を `gpt-5.6-sol` に変更。

- トップレベル `model`
- `[profiles.fast]`
- `[profiles.xhigh]`

`[profiles.codex*]`（`gpt-5.3-codex` 系）は今回のスコープ外のため変更なし。

https://claude.ai/code/session_01AkBpZdUXZmRAf3x9cV14Fe