### PR TITLE
feat: Codex Default mode で request_user_input を有効化

### DIFF
--- a/dot_codex/modify_config.toml
+++ b/dot_codex/modify_config.toml
@@ -52,6 +52,7 @@ unified_exec = true
 shell_snapshot = true
 prevent_idle_sleep = true
 multi_agent_v2 = true
+default_mode_request_user_input = true
 
 [sandbox_workspace_write]
 network_access = true


### PR DESCRIPTION
## Why

Codex の Plan mode を使わず Default mode で計画を進める運用では、既定状態だと `request_user_input` が公開されず、Claude の `AskUserQuestion` 相当の確認を計画中に行えないためです。[Codex v0.143.0 の feature registry](https://github.com/openai/codex/blob/rust-v0.143.0/codex-rs/features/src/lib.rs) では、この feature flag が Default collaboration mode で `request_user_input` を許可する設定として定義されています。

## What

- `dot_codex/modify_config.toml` の `[features]` に `default_mode_request_user_input = true` を追加
- Default mode でも `request_user_input` を利用可能に変更
- Plan mode の設定、developer instructions、Codex バージョンは変更なし
- 検証: Codex CLI v0.143.0 の `--strict-config`、`codex features list`、chezmoi 対象 dry-run、`git diff --check`

```diff
 [features]
 multi_agent_v2 = true
+default_mode_request_user_input = true
```