### PR TITLE
feat(statusline): weekly limit の解除時刻を表示し曜日を括弧で囲む

### DIFF
--- a/go/cmd/cc-statusline/main.go
+++ b/go/cmd/cc-statusline/main.go
@@ -95,7 +95,7 @@ func formatResetTime(epoch int64, now time.Time, weekly bool) string {
 	}
 	if weekly {
 		weekdays := [...]string{"日", "月", "火", "水", "木", "金", "土"}
-		return fmt.Sprintf("(~%d/%d%s)", int(t.Month()), t.Day(), weekdays[t.Weekday()])
+		return fmt.Sprintf("(~%d/%d(%s) %d:%02d)", int(t.Month()), t.Day(), weekdays[t.Weekday()], t.Hour(), t.Minute())
 	}
 	return fmt.Sprintf("(~%d:%02d)", t.Hour(), t.Minute())
 }

--- a/go/cmd/cc-statusline/main_test.go
+++ b/go/cmd/cc-statusline/main_test.go
@@ -119,10 +119,11 @@ func TestFormatResetTime(t *testing.T) {
 		weekly bool
 		want   string
 	}{
-		"zero":      {epoch: 0, weekly: false, want: ""},
-		"past":      {epoch: now.Add(-1 * time.Hour).Unix(), weekly: false, want: ""},
-		"future_5h": {epoch: time.Date(2026, 3, 23, 15, 30, 0, 0, time.Local).Unix(), weekly: false, want: "(~15:30)"},
-		"future_7d": {epoch: time.Date(2026, 3, 25, 0, 0, 0, 0, time.Local).Unix(), weekly: true, want: "(~3/25水)"},
+		"zero":                {epoch: 0, weekly: false, want: ""},
+		"past":                {epoch: now.Add(-1 * time.Hour).Unix(), weekly: false, want: ""},
+		"future_5h":           {epoch: time.Date(2026, 3, 23, 15, 30, 0, 0, time.Local).Unix(), weekly: false, want: "(~15:30)"},
+		"future_7d":           {epoch: time.Date(2026, 3, 25, 0, 0, 0, 0, time.Local).Unix(), weekly: true, want: "(~3/25(水) 0:00)"},
+		"future_7d_with_time": {epoch: time.Date(2026, 3, 25, 9, 5, 0, 0, time.Local).Unix(), weekly: true, want: "(~3/25(水) 9:05)"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Why

statusline の 7d（weekly limit）の解除タイミングが日付までしか出ておらず、その日の何時に復活するのかが分からなかった。また曜日が日付に直結していて読みづらかった。

## What

`formatResetTime` の weekly 表示に時刻を追加し、曜日を括弧で囲んだ。

- before: `7d:42%(~3/25水)`
- after: `7d:42%(~3/25(水) 0:00)`

5h 側の表示は変更なし。`go test ./go/...` は通っている。

なお調査の結果、Claude Code 2.1.207 の statusline に渡る `rate_limits` は `five_hour` / `seven_day` の 2 枠のみで、Fable 枠（内部名 `seven_day_overage_included` / `model_scoped[]`）は payload に含まれていないため、この PR では扱っていない。

(by Claude Code)
