### PR TITLE
fix(ccgate): グローバル/システムパッケージインストールを auto-allow しない

### DIFF
--- a/ccgate.libsonnet
+++ b/ccgate.libsonnet
@@ -18,7 +18,7 @@ local config(opts) = base {
     'Safe PR Metadata Update: If the operation updates an existing pull request in the trusted repository and only changes title and/or body/description text, allow immediately. If it changes review state, draft status (especially draft=false / ready-for-review), open/closed state, base/head branch, reviewers, assignees, labels, milestone, merge settings, or maintainer permissions, fall through.',
     'Local Development: Build, test, lint, format commands in the current repository.',
     'Git Feature Branch: Git operations on non-protected branches (not main, master, release/*, prod). ' + opts.gitBranchContext,
-    'Package Manager Install: Package manager install/sync commands in the current repository.',
+    'Package Manager Install: Project-scoped dependency install/sync that resolves dependencies declared in the current repository (e.g. npm/pnpm/yarn install, go mod download/tidy, uv sync, pip install -r within a project venv, bundle install, cargo fetch, mise/aqua install of already-declared tools). This does NOT include commands that install software system-wide or globally, outside the repository: Homebrew (brew install/upgrade/reinstall/tap), OS package managers (apt, apt-get, dnf, yum, pacman, apk, zypper), or globally-scoped installs (npm/pnpm/yarn add -g, npm -g install, pipx install, cargo install, go install). Those mutate machine state beyond the repo and MUST fall through.',
   ],
 
   deny: [


### PR DESCRIPTION
## Why

ccgate（PermissionRequest hook）が `brew install <pkg>` を確認なしで auto-allow してしまう事象があった。`brew install` は `/opt/homebrew` 配下にシステム全体で書き込むグローバル操作であり、current repository 内の依存インストールとは別物。ユーザーの明示的許可なくマシン環境を変更してしまう。

原因は `ccgate.libsonnet` の allow ルールが広すぎたこと:

> Package Manager Install: Package manager install/sync commands in the current repository.

判定モデル（haiku）がこれを緩く解釈し、システムグローバルなインストールを排除できていなかった。`in the current repository` という限定が自然言語として弱かった。

## What

`ccgate.libsonnet` の "Package Manager Install" allow ルールを、プロジェクトスコープ限定 + グローバル/システムインストール明示除外に差し替えた。

- allow の対象を「repo に宣言済みの依存を解決するインストール」（`npm/pnpm install`, `go mod download`, `mise/aqua install` 等）に限定
- Homebrew / OS パッケージマネージャ（apt, dnf, pacman 等）/ グローバルインストール（`-g`, `pipx`, `cargo install`, `go install` 等）を明示除外 → allow にも deny にもマッチせず **fall through（毎回ユーザー確認プロンプト）** になる
- deny には**しない**（本当に必要な時はユーザーが承認できる）
- `ccgate.libsonnet` は `dot_claude/ccgate.jsonnet` / `dot_codex/ccgate.jsonnet` の両方が import するため、1ファイルの修正で Claude / Codex 両方に反映される

検証: `jsonnet dot_claude/ccgate.jsonnet` / `dot_codex/ccgate.jsonnet` がパースエラーなく生成され、新ルール文言が反映されていることを確認済み。

https://claude.ai/code/session_01MAg2hwbhm8qWyNGKwrtxvM