### PR TITLE
feat: claudex（Claude Code のハーネスを GPT-5.6 Sol で駆動する）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,17 @@ Homebrew
 - **mise** (`dot_config/mise/`, `dot_local/bin/executable_mise`): ランタイム、CLI ツール、npm パッケージの統合管理。bootstrap 方式でインストール
 - **aqua** (`dot_config/aquaproj-aqua/`): mise lock で checksum が取得できないツールを管理。aqua CLI 自体は mise でインストール
 
+### claudex（Claude Code を GPT-5.6 Sol で駆動する）
+
+`dot_zsh/functions/claudex.zsh` が提供する `claudex` コマンドは、Claude Code のハーネス（ツールループ・サブエージェント・hooks・MCP）をそのままに、推論するモデルだけを GPT-5.6 Sol に差し替える。`claude-code-proxy`（mise の `github:` backend で導入）が Anthropic Messages API 互換のプロキシとして `127.0.0.1:18765` に立ち、ChatGPT サブスクの OAuth 経由で Codex backend に転送する。初回のみ `claude-code-proxy codex auth login` が必要。
+
+- 素の `claude` は従来通り Claude サブスク / Opus で動く。`claudex` 使用中は Anthropic にリクエストが飛ばないため Claude の quota は減らず、代わりに ChatGPT 側の quota を消費する
+- プロキシはマシン単位で 1 プロセス。worktree ごとには立たず、全 worktree・全セッションが 1 つを共有する（`claudex` が未起動時のみ自動起動する）
+- Anthropic は非 Claude モデルへの gateway ルーティングを公式サポートしていない。壊れても直らない前提で使う
+- `CLAUDE_CODE_AUTO_COMPACT_WINDOW` を `settings.jsonnet` の `env` ではなく `dot_zshenv.tmpl` で export しているのは、`claudex` がモデルの context 長に合わせて上書きできるようにするため
+
+これは既に有効化されている `codex@openai-codex` プラグイン（Claude Code から Codex CLI に作業を委譲する）とは別物で、両立する。
+
 ### 自動生成ファイル一覧
 
 | ファイル | 生成元 | 生成方法 |

--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -259,7 +259,9 @@ local autoModeRules = import 'auto-mode.libsonnet';
     MCP_TIMEOUT: '600000',
     MCP_TOOL_TIMEOUT: '600000',
     MAX_MCP_OUTPUT_TOKENS: '100000',  // default: 25000
-    CLAUDE_CODE_AUTO_COMPACT_WINDOW: '500000',
+    // CLAUDE_CODE_AUTO_COMPACT_WINDOW は dot_zshenv.tmpl で export している。
+    // claudex（proxy 経由で GPT-5.6 Sol を使う）が context 長に合わせて上書きするため、
+    // settings.json 側には置かない
     // adaptive thinking (effortLevel) が有効な場合、以下は不要
     // MAX_THINKING_TOKENS: '31199',
     // CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: '1',  // これを設定すると MAX_THINKING_TOKENS に戻る

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -111,6 +111,8 @@ go = "1.26.5"
 "aqua:openai/codex" = "0.144.3"
 "aqua:anomalyco/opencode" = "1.17.15"
 "aqua:x.ai/cli/grok" = "0.2.51" # Grok Build CLI (xAI のターミナル向けコーディングエージェント)
+# Claude Code のハーネスを ChatGPT サブスクの Codex backend に向ける Anthropic 互換プロキシ。claudex から使う
+"github:raine/claude-code-proxy" = { version = "v0.1.17", matching_regex = '\.tar\.gz$' }
 "npm:ccusage" = "20.0.17"
 "npm:@typescript/native-preview" = "7.0.0-dev.20260707.2"
 "npm:cc-sdd" = "3.0.2"

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -1502,6 +1502,43 @@ url = "https://github.com/jgm/pandoc/releases/download/3.10/pandoc-3.10-windows-
 url_api = "https://api.github.com/repos/jgm/pandoc/releases/assets/438414170"
 provenance = "github-attestations"
 
+[[tools."github:raine/claude-code-proxy"]]
+version = "0.1.17"
+backend = "github:raine/claude-code-proxy"
+
+[tools."github:raine/claude-code-proxy".options]
+matching_regex = '\.tar\.gz$'
+
+[tools."github:raine/claude-code-proxy"."platforms.linux-arm64"]
+checksum = "sha256:76c3c28e044fd779655f57be1048924330492fb5eb65cdabaa21d3fa8543d139"
+url = "https://github.com/raine/claude-code-proxy/releases/download/v0.1.17/claude-code-proxy-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/raine/claude-code-proxy/releases/assets/475934107"
+
+[tools."github:raine/claude-code-proxy"."platforms.linux-arm64-musl"]
+checksum = "sha256:76c3c28e044fd779655f57be1048924330492fb5eb65cdabaa21d3fa8543d139"
+url = "https://github.com/raine/claude-code-proxy/releases/download/v0.1.17/claude-code-proxy-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/raine/claude-code-proxy/releases/assets/475934107"
+
+[tools."github:raine/claude-code-proxy"."platforms.linux-x64"]
+checksum = "sha256:24057ea37c4ad386f0a0e3d257dc9b734d220f717fbd57114dc003a61e4a79be"
+url = "https://github.com/raine/claude-code-proxy/releases/download/v0.1.17/claude-code-proxy-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/raine/claude-code-proxy/releases/assets/475934111"
+
+[tools."github:raine/claude-code-proxy"."platforms.linux-x64-musl"]
+checksum = "sha256:24057ea37c4ad386f0a0e3d257dc9b734d220f717fbd57114dc003a61e4a79be"
+url = "https://github.com/raine/claude-code-proxy/releases/download/v0.1.17/claude-code-proxy-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/raine/claude-code-proxy/releases/assets/475934111"
+
+[tools."github:raine/claude-code-proxy"."platforms.macos-arm64"]
+checksum = "sha256:547ca330f3ee553ab697d695fb7117a12ab1b63ae629287c30b8c7cd4baca329"
+url = "https://github.com/raine/claude-code-proxy/releases/download/v0.1.17/claude-code-proxy-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/raine/claude-code-proxy/releases/assets/475934103"
+
+[tools."github:raine/claude-code-proxy"."platforms.macos-x64"]
+checksum = "sha256:070149ecffedd0e5efeba4a7aa2b7a60fd0b0bf479484990647b0f172a86f7d1"
+url = "https://github.com/raine/claude-code-proxy/releases/download/v0.1.17/claude-code-proxy-darwin-amd64.tar.gz"
+url_api = "https://api.github.com/repos/raine/claude-code-proxy/releases/assets/475934106"
+
 [[tools."github:sivchari/gopls-lazy"]]
 version = "0.3.0"
 backend = "github:sivchari/gopls-lazy"

--- a/dot_zsh/functions/claudex.zsh
+++ b/dot_zsh/functions/claudex.zsh
@@ -1,0 +1,85 @@
+# claudex: Claude Code のハーネスのまま、モデルだけ GPT-5.6 Sol にする
+#
+# claude-code-proxy が Anthropic Messages API 互換のプロキシとして立ち、ChatGPT サブスクの
+# OAuth 経由で Codex backend に転送する。ツールループ・サブエージェント・hooks・MCP は Claude
+# Code のものがそのまま効き、推論するモデルだけが入れ替わる。
+#
+# 初回のみ認証が必要:
+#   claude-code-proxy codex auth login   # ChatGPT Plus/Pro アカウントでログイン
+#
+# 注意:
+#   - 消費するのは ChatGPT 側の quota。Claude のサブスクは減らない（素の claude は従来通り）
+#   - プロキシはマシン単位で 1 プロセス。全 worktree・全セッションが 1 つを共有する
+#   - Anthropic は非 Claude モデルへの gateway ルーティングを公式サポートしていない
+#
+# 上書き用の環境変数: CLAUDEX_MODEL, CLAUDEX_SMALL_MODEL, CLAUDEX_PORT
+#   例) CLAUDEX_MODEL='gpt-5.6-sol-fast[1m]' claudex   # priority tier で叩く
+
+# ポートが listen されているか（外部コマンドに依存せず zsh 組み込みで確認する）
+_claudex_port_open() {
+    zmodload zsh/net/tcp 2>/dev/null || return 1
+    if ztcp 127.0.0.1 "$1" 2>/dev/null; then
+        ztcp -c "$REPLY"
+        return 0
+    fi
+    return 1
+}
+
+# プロキシが生きていなければ起動する。同時に複数の claudex が走っても二重起動しないよう
+# mkdir のアトミック性でロックを取り、ロックを取れなかった側は起動を待つだけにする
+_claudex_ensure_proxy() {
+    local port="${CLAUDEX_PORT:-18765}"
+    _claudex_port_open "$port" && return 0
+
+    if ! command -v claude-code-proxy >/dev/null 2>&1; then
+        echo "エラー: claude-code-proxy が見つかりません（mise install で導入されます）" >&2
+        return 1
+    fi
+
+    if ! claude-code-proxy codex auth status >/dev/null 2>&1; then
+        echo "エラー: Codex が未認証です。'claude-code-proxy codex auth login' を実行してください" >&2
+        return 1
+    fi
+
+    local lockdir="${TMPDIR:-/tmp}/claudex-${port}.lock"
+    if mkdir "$lockdir" 2>/dev/null; then
+        local logdir="${XDG_STATE_HOME:-$HOME/.local/state}/claude-code-proxy"
+        mkdir -p "$logdir"
+        PORT="$port" nohup claude-code-proxy serve --no-monitor >>"$logdir/serve.log" 2>&1 &
+        disown
+        rmdir "$lockdir" 2>/dev/null
+    fi
+
+    local i
+    for i in {1..50}; do
+        _claudex_port_open "$port" && return 0
+        sleep 0.1
+    done
+
+    echo "エラー: claude-code-proxy が 127.0.0.1:${port} で起動しませんでした" >&2
+    echo "  ログ: ${XDG_STATE_HOME:-$HOME/.local/state}/claude-code-proxy/serve.log" >&2
+    return 1
+}
+
+claudex() {
+    _claudex_ensure_proxy || return 1
+
+    local model="${CLAUDEX_MODEL:-gpt-5.6-sol[1m]}"
+
+    # [1m] は Claude Code 側の compaction 閾値を動かすためのサフィックスで、proxy が upstream に
+    # 送る前に剥がす。CLAUDE_CODE_SUBAGENT_MODEL には付けない（サブエージェントが Opus を継承する
+    # のを防ぐのが目的で、閾値制御は不要）
+    #
+    # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC は settings.jsonnet と同様に設定しない
+    # （remote-control の eligibility チェックがブロックされるため）。無駄なモデル呼び出し自体は
+    # settings.jsonnet の DISABLE_NON_ESSENTIAL_MODEL_CALLS で既に止まっている
+    ANTHROPIC_BASE_URL="http://127.0.0.1:${CLAUDEX_PORT:-18765}" \
+    ANTHROPIC_AUTH_TOKEN="unused" \
+    ANTHROPIC_SMALL_FAST_MODEL="${CLAUDEX_SMALL_MODEL:-gpt-5.6-luna[1m]}" \
+    CLAUDE_CODE_SUBAGENT_MODEL="${model%\[*}" \
+    CLAUDE_CODE_AUTO_COMPACT_WINDOW=272000 \
+    CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=3 \
+    CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1 \
+    ENABLE_TOOL_SEARCH=false \
+        command claude --model "$model" "$@"
+}

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -26,3 +26,6 @@ export MISE_GLOBAL_CONFIG_FILE="${XDG_CONFIG_HOME}/mise/config.toml"
 # Claude Code auto updater を無効化
 export CLAUDE_CODE_AUTO_UPDATE=false
 export DISABLE_AUTOUPDATER=1
+
+# Opus の 1M context 前提の auto-compact 閾値。claudex は context の短いモデルに合わせて上書きする
+export CLAUDE_CODE_AUTO_COMPACT_WINDOW=500000


### PR DESCRIPTION
## Why

2026-07-12 に OpenAI の Head of Product である Tibo (@thsottiaux) が「Claude Code をそのまま使いつつ、モデルだけ GPT-5.6 Sol に差し替える」手順を公開した（[該当ポスト](https://x.com/thsottiaux/status/2076119366647894371)）。発端は Theo の「gpt-5.6-sol は Codex CLI より Claude Code のハーネスで動かした方が明確に良い」という検証。

Claude Code は `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` を参照するので、ローカルに Anthropic Messages API 互換のプロキシを立てれば、ツールループ・サブエージェント・plan mode・hooks・MCP を Claude Code のまま残して、推論するモデルだけを差し替えられる。これを ChatGPT サブスクの quota で試せるようにする。

既存の `claude`（Claude サブスク / Opus）は一切壊さず、`claudex` というコマンドを 1 つ増やすだけにしている。

## What

- **`dot_config/mise/config.toml`**: [raine/claude-code-proxy](https://github.com/raine/claude-code-proxy)（Rust / MIT）を `github:` backend で追加。aqua-registry には無いが、Renovate の mise manager は github backend を認識するので自動更新に乗る。リリース資産に `.sha256` と `.zip` が混ざるので `matching_regex` で tar.gz に絞っている
- **`dot_zsh/functions/claudex.zsh`**（新規）: プロキシの自動起動と `claude` の起動をまとめた `claudex` 関数。`dot_zshrc.tmpl` が `~/.zsh/functions/*.zsh` を自動 source するので、置くだけで有効になる
- **`CLAUDE_CODE_AUTO_COMPACT_WINDOW` の移動**: `dot_claude/settings.jsonnet` の `env` から `dot_zshenv.tmpl` の export に移した。Opus の 1M context 前提の 500000 のままだと、context 272K の Sol では auto-compact が発火する前に上限に当たる。settings.json の `env` と shell の export はどちらが勝つかドキュメント上の記述が揺れているため、shell 側に一本化して `claudex` が確実に上書きできる状態にした。通常の `claude` の挙動は不変
- **`CLAUDE.md`**: claudex の説明を追記

### プロキシは worktree ごとには立たない

`127.0.0.1:18765` を listen するマシン単位の 1 プロセスを、全 worktree・全セッションが共有する。`claudex` はポートを叩いて生きていれば再利用し、死んでいれば起動するだけ。同時起動レースは `mkdir` のアトミック性でロックして潰している。

### 選定理由（CLIProxyAPI ではなく claude-code-proxy）

Tibo が名指ししたのは CLIProxyAPI だが、あちらは多プロバイダ対応の汎用ゲートウェイで Claude Code 固有の作り込みが薄い。Tibo の alias が `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1` 等を並べているのは、その穴を環境変数で外から埋めているため。claude-code-proxy は Claude Code 専用設計で、`/effort` UI → Codex `reasoning.effort` のマッピング、`ANTHROPIC_SMALL_FAST_MODEL` の分離、reasoning summary → thinking ブロック変換、`[1m]` による compaction 閾値制御、セッション内 `/model` 切替が最初から効く。トレードオフはメンテ規模が小さいこと（star 291 vs 41.7k）。

### 制約

- 消費するのは **ChatGPT Plus/Pro 側の quota**。プロキシ経由中は Anthropic にリクエストが飛ばないので Claude の quota は減らない。Claude と GPT はセッション単位で排他
- **Anthropic は非 Claude モデルへの gateway ルーティングを公式サポートしていない**（禁止ではなくサポート対象外 / [llm-gateway](https://code.claude.com/docs/en/llm-gateway.md)）。壊れても直らない前提
- OpenAI 側は事実上の黙認（Head of Product 本人が手順を公開）だが正式な規約文言ではない
- レート制限は ChatGPT アカウント単位で全クライアント共有（Codex CLI と食い合う）
- `tool_result` に埋まった画像は `[image omitted]` になる。Codex の raw reasoning ブロックは渡らない（summary は thinking ブロックに変換される）
- 既に有効な `codex@openai-codex` プラグイン（Codex CLI への委譲）とは別物で、両立する

### 検証済み

- `mise install` が `claude-code-proxy-darwin-arm64.tar.gz` を正しく選択し、SLSA provenance 検証を通してインストールされる（`claude-code-proxy 0.1.17`）
- 未認証時に `claudex` が `claude-code-proxy codex auth login` を促して abort する
- 3 並列で `claudex` を起動してもプロキシの listener は 1 つだけ（ロックが機能）
- プロキシが Anthropic Messages 形式のリクエストを受け、Anthropic のエラー形式で返す
- `task check` が通る

**未検証（要ユーザー操作）**: `claude-code-proxy codex auth login` はブラウザ OAuth が必要なため、実際に Sol が応答するところまでは未確認。

## Todo

- [ ] `claude-code-proxy codex auth login` 後、`claudex` で実際に Sol が応答することを確認
- [ ] 素の `claude` が Opus / Claude サブスクのままであることを確認
- [ ] ccgate の PermissionRequest hook が Sol 上でも動くことを確認

https://claude.ai/code/session_01NqfvJkL7QkYwXqXvhg5fjB
