### PR TITLE
fix: run_onchange の PATH で aqua-proxy が mise 管理ツールを隠すのを防ぐ

### DIFF
--- a/.chezmoitemplates/path-setup.tmpl
+++ b/.chezmoitemplates/path-setup.tmpl
@@ -9,8 +9,13 @@ export PATH="/opt/homebrew/bin:$PATH"
 export PATH="/usr/local/bin:$PATH"
 {{-   end }}
 {{- end }}
-# mise 管理ツール（claude/node 等）を Homebrew 等より優先する。
+# aqua CLI 直管理のツール（aws-cli, op, zoxide）。
+# aqua の bin は過去に管理していたツールの aqua-proxy symlink が残り続けるため、
+# mise 管理ツールを追い越さないよう mise shims より後ろに置く。
+# 例: 孤児化した bin/go -> aqua-proxy が mise の go を隠すと、mise が go backend の
+# 子プロセスから shims を外した瞬間に aqua-proxy が aqua を見失い、go install が落ちる。
+export PATH="${XDG_DATA_HOME}/aquaproj-aqua/bin:$PATH"
+# mise 管理ツール（claude/node/go 等）を aqua・Homebrew 等より優先する。
 # これが無いと run_onchange 内で /opt/homebrew/bin の野良ツールが mise 版を追い越して呼ばれる。
 export PATH="${XDG_DATA_HOME}/mise/shims:$PATH"
-export PATH="${XDG_DATA_HOME}/aquaproj-aqua/bin:$PATH"
 export AQUA_GLOBAL_CONFIG="${AQUA_GLOBAL_CONFIG:-}:${XDG_CONFIG_HOME}/aquaproj-aqua/aqua.yaml"


### PR DESCRIPTION
## Why

`chezmoi update` の `run_onchange_after_10-mise-install.sh.tmpl` が `mise install` に失敗するようになった。

```
[ERROR] get aqua's absolute path: aqua isn't found: exec: "aqua": executable file not found in $PATH
mise ERROR go failed
mise ERROR Failed to install go:golang.org/x/tools/gopls@v0.23.0: go exited with non-zero status: exit code 1
chezmoi: 10-mise-install.sh: exit status 1
```

原因は `.chezmoitemplates/path-setup.tmpl` の PATH 構築順序。aqua の bin を mise shims より**後**に prepend していたため、最終的な PATH で aqua が mise を追い越していた。

```
$XDG_DATA_HOME/aquaproj-aqua/bin   ← 先頭
$XDG_DATA_HOME/mise/shims
/opt/homebrew/bin
...
```

aqua の bin には過去に管理していたツールの aqua-proxy symlink が孤児として残り続ける。実際 `bin/go -> ../aqua-proxy`（2026-01-05 付）が残っており、`aqua.yaml` に `go` は無いのにこれが mise の `go` を隠していた。さらに mise は go backend の子プロセスから shims を PATH から外すため、その瞬間 aqua-proxy が `aqua`（mise shims 経由でしか存在しない）を見失い、`go install` が落ちる。

go を 1.26.4 → 1.26.5 に上げた #789 で go backend のツールが再ビルド対象になり、そこで初めて表面化した。対話シェルは `.zprofile` の `mise activate zsh --shims` が後から shims を先頭に積むため影響が無く、run_onchange スクリプトだけが踏んでいた（手動の `mise install` が通るのはこのため）。

## What

`.chezmoitemplates/path-setup.tmpl` で aqua の bin を mise shims より**先に** prepend し、mise shims が PATH の先頭に来るようにした。12-14 行目のコメントが元々表明していた「mise 管理ツールを優先する」という意図が、直後の行で打ち消されていたのを直したかたち。

aqua CLI 直管理のツール（aws-cli, 1password/cli, zoxide）は他が提供しないため、順序を下げても引き続き解決される。

## 検証

同一コマンドを新旧の PATH 順序で実行して切り分けた。

```
########## 現状の PATH 順序（aqua が先） ##########
mise go:golang.org/x/tools/gopls@0.23.0  [2/4] install
[ERROR] get aqua's absolute path: aqua isn't found: exec: "aqua": executable file not found in $PATH

########## 修正後の PATH 順序（mise shims が先） ##########
mise go:golang.org/x/tools/gopls@0.23.0  [1/3] install
mise go:golang.org/x/tools/gopls@0.23.0 ✓ installed
```

`chezmoi execute-template` でレンダリング結果の PATH 順序も確認済み。

https://claude.ai/code/session_01NqfvJkL7QkYwXqXvhg5fjB
