### PR TITLE
fix(claudex): [1m] を外し compact 窓をバックエンドのキャップ内に収める

### DIFF
--- a/dot_zsh/functions/claudex.zsh
+++ b/dot_zsh/functions/claudex.zsh
@@ -12,8 +12,9 @@
 #   - プロキシはマシン単位で 1 プロセス。全 worktree・全セッションが 1 つを共有する
 #   - Anthropic は非 Claude モデルへの gateway ルーティングを公式サポートしていない
 #
-# 上書き用の環境変数: CLAUDEX_MODEL, CLAUDEX_SMALL_MODEL, CLAUDEX_PORT
-#   例) CLAUDEX_MODEL='gpt-5.6-sol-fast[1m]' claudex   # priority tier で叩く
+# 上書き用の環境変数: CLAUDEX_MODEL, CLAUDEX_SMALL_MODEL, CLAUDEX_PORT, CLAUDEX_COMPACT_WINDOW
+#   例) CLAUDEX_MODEL='gpt-5.6-sol-fast' claudex        # priority tier で叩く
+#   例) CLAUDEX_COMPACT_WINDOW=300000 claudex           # バックエンドが安定して 353K 出るとき
 
 # ポートが listen されているか（外部コマンドに依存せず zsh 組み込みで確認する）
 _claudex_port_open() {
@@ -64,20 +65,26 @@ _claudex_ensure_proxy() {
 claudex() {
     _claudex_ensure_proxy || return 1
 
-    local model="${CLAUDEX_MODEL:-gpt-5.6-sol[1m]}"
+    local model="${CLAUDEX_MODEL:-gpt-5.6-sol}"
 
-    # [1m] は Claude Code 側の compaction 閾値を動かすためのサフィックスで、proxy が upstream に
-    # 送る前に剥がす。CLAUDE_CODE_SUBAGENT_MODEL には付けない（サブエージェントが Opus を継承する
-    # のを防ぐのが目的で、閾値制御は不要）
+    # [1m] サフィックスは付けない。gpt-5.6-sol は API では 1.05M context だが、claudex が
+    # 経由する ChatGPT/Codex バックエンドでは実効 ~353K（raw 372K）にキャップされ、regression で
+    # 258K まで下がることもある（openai/codex#31860, #32806）。[1m] を付けると CC が「1M ある」と
+    # 誤認して auto-compact を焚かず、~372K の壁に激突する。しかも壁に当たってからの compact は
+    # 全 context を要約に送るため同じ上限を超えて失敗し、デッドロックする。
+    #
+    # そのため CLAUDE_CODE_AUTO_COMPACT_WINDOW をバックエンドのキャップより十分下に設定し、
+    # 壁に当たる前に必ず compact させる。regression（258K）でも余裕を残すため 220000 とする。
+    # CLAUDEX_COMPACT_WINDOW で上書き可能。
     #
     # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC は settings.jsonnet と同様に設定しない
     # （remote-control の eligibility チェックがブロックされるため）。無駄なモデル呼び出し自体は
     # settings.jsonnet の DISABLE_NON_ESSENTIAL_MODEL_CALLS で既に止まっている
     ANTHROPIC_BASE_URL="http://127.0.0.1:${CLAUDEX_PORT:-18765}" \
     ANTHROPIC_AUTH_TOKEN="unused" \
-    ANTHROPIC_SMALL_FAST_MODEL="${CLAUDEX_SMALL_MODEL:-gpt-5.6-luna[1m]}" \
+    ANTHROPIC_SMALL_FAST_MODEL="${CLAUDEX_SMALL_MODEL:-gpt-5.6-luna}" \
     CLAUDE_CODE_SUBAGENT_MODEL="${model%\[*}" \
-    CLAUDE_CODE_AUTO_COMPACT_WINDOW=272000 \
+    CLAUDE_CODE_AUTO_COMPACT_WINDOW="${CLAUDEX_COMPACT_WINDOW:-220000}" \
     CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=3 \
     CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1 \
     ENABLE_TOOL_SEARCH=false \

--- a/dot_zsh/functions/claudex.zsh
+++ b/dot_zsh/functions/claudex.zsh
@@ -14,7 +14,7 @@
 #
 # 上書き用の環境変数: CLAUDEX_MODEL, CLAUDEX_SMALL_MODEL, CLAUDEX_PORT, CLAUDEX_COMPACT_WINDOW
 #   例) CLAUDEX_MODEL='gpt-5.6-sol-fast' claudex        # priority tier で叩く
-#   例) CLAUDEX_COMPACT_WINDOW=300000 claudex           # バックエンドが安定して 353K 出るとき
+#   例) CLAUDEX_COMPACT_WINDOW=250000 claudex           # backend が 272K に巻き戻った日は下げる
 
 # ポートが listen されているか（外部コマンドに依存せず zsh 組み込みで確認する）
 _claudex_port_open() {
@@ -67,16 +67,23 @@ claudex() {
 
     local model="${CLAUDEX_MODEL:-gpt-5.6-sol}"
 
-    # [1m] サフィックスは付けない。gpt-5.6-sol は API では 1.05M context だが、claudex が
-    # 経由する ChatGPT/Codex バックエンドでは実効 ~353K（raw 372K）にキャップされ、regression で
-    # 258K まで下がることもある（openai/codex#31860, #32806）。[1m] を付けると CC が「1M ある」と
-    # 誤認して auto-compact を焚かず、~372K の壁に激突する。しかも壁に当たってからの compact は
-    # 全 context を要約に送るため同じ上限を超えて失敗し、デッドロックする。
+    # [1m] サフィックスは付けない。gpt-5.6-sol は API では 1.05M context だが、claudex が経由する
+    # ChatGPT/Codex バックエンドでは context がキャップされる（実測で ~372K まで到達を確認）。OpenAI は
+    # 372K で課金が想定超だったため Codex の default を一時 272K に戻し、数日かけて 372K に戻すと
+    # アナウンスした（thsottiaux 2076495156757577895 / openai/codex#31860, #32806）ので、当面 272K↔372K
+    # で揺れうる。[1m] を付けると CC が「1M ある」と誤認して auto-compact を焚かず壁に激突する。壁に
+    # 当たってからの compact は現 context 全量を要約に送るため同じ上限を超えて失敗し、デッドロックする。
     #
-    # そのため CLAUDE_CODE_AUTO_COMPACT_WINDOW をバックエンドのキャップより十分下に設定し、
-    # 壁に当たる前に必ず compact させる。regression（258K）でも余裕を残すため 220000 とする。
-    # CLAUDEX_COMPACT_WINDOW で上書き可能。
+    # 既定は観測済みの 372K キャップに合わせて 360000（compact は窓の約9割手前 ~331K で焚かれ、summary
+    # 呼び出しが 372K の壁の内側で完了する）。もし backend が 272K に巻き戻った日に "Context limit
+    # reached" のデッドロックが再発したら、その時だけ CLAUDEX_COMPACT_WINDOW=250000 のように下げる。
     #
+    # これは OS 環境変数ではなく --settings（CLI 引数）で渡す。settings ファイルの env は OS 環境変数に
+    # 勝つため、プロジェクトの .claude/settings.json が env.CLAUDE_CODE_AUTO_COMPACT_WINDOW を設定して
+    # いると OS env 注入では負ける。優先順位は Managed > Command-line > Local > Project > User なので、
+    # --settings で渡せば project 設定にも勝てる（settings.md）。
+    local compact_settings="{\"env\":{\"CLAUDE_CODE_AUTO_COMPACT_WINDOW\":\"${CLAUDEX_COMPACT_WINDOW:-360000}\"}}"
+
     # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC は settings.jsonnet と同様に設定しない
     # （remote-control の eligibility チェックがブロックされるため）。無駄なモデル呼び出し自体は
     # settings.jsonnet の DISABLE_NON_ESSENTIAL_MODEL_CALLS で既に止まっている
@@ -84,9 +91,8 @@ claudex() {
     ANTHROPIC_AUTH_TOKEN="unused" \
     ANTHROPIC_SMALL_FAST_MODEL="${CLAUDEX_SMALL_MODEL:-gpt-5.6-luna}" \
     CLAUDE_CODE_SUBAGENT_MODEL="${model%\[*}" \
-    CLAUDE_CODE_AUTO_COMPACT_WINDOW="${CLAUDEX_COMPACT_WINDOW:-220000}" \
     CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=3 \
     CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1 \
     ENABLE_TOOL_SEARCH=false \
-        command claude --model "$model" "$@"
+        command claude --model "$model" --settings "$compact_settings" "$@"
 }


### PR DESCRIPTION
## Why

claudex（#807）で GPT-5.6 Sol を実タスクに使ったところ、`Context limit reached · /compact or /clear to continue` が出てセッションがデッドロックした（実セッションで 370288 tokens を確認）。

原因は2つの設定不整合:

1. **`[1m]` サフィックスによる context 誤認**: claudex は `--model gpt-5.6-sol[1m]` を渡していた。`[1m]` は CC に「context は 1M」と信じさせるが、claudex が経由する ChatGPT/Codex バックエンドの Sol は実測 ~372K でキャップされる（API の Sol は 1.05M だが、サブスク経由は別。OpenAI は課金都合で Codex default を 272K↔372K で動かしている — [thsottiaux](https://x.com/thsottiaux/status/2076495156757577895) / [openai/codex#31860](https://github.com/openai/codex/issues/31860), [#32806](https://github.com/openai/codex/issues/32806)）。CC は「1M ある」と思って auto-compact を焚かず、~372K の壁に激突。壁に当たってからの compact は現 context 全量を要約に送るため同じ上限を超えて失敗し、デッドロックする。

2. **OS 環境変数がプロジェクト設定に負ける**: 安全弁として入れていた `CLAUDE_CODE_AUTO_COMPACT_WINDOW` を OS 環境変数で注入していたが、settings ファイルの `env` は OS 環境変数に勝つ（[env-vars.md](https://code.claude.com/docs/en/env-vars.md)）。実際 work プロジェクトの `.claude/settings.json` が `env.CLAUDE_CODE_AUTO_COMPACT_WINDOW: '750000'`（Opus 用）を設定しており、claudex の値が握り潰されていた。

## What

`dot_zsh/functions/claudex.zsh`:

- **model / small model から `[1m]` を除去**（`gpt-5.6-sol` / `gpt-5.6-luna`）。CC に嘘の 1M を信じさせない
- **compact 窓を `--settings`（CLI 引数）で渡す**。優先順位は Managed > **Command-line** > Local > Project > User（[settings.md](https://code.claude.com/docs/en/settings.md)）なので、project の `settings.json`（750000）にも勝てる
- **既定値 360000**。観測済みの 372K キャップに合わせ、auto-compact が窓の約9割手前 ~331K で焚かれ、summary 呼び出しが 372K の壁の内側で完了する。`CLAUDEX_COMPACT_WINDOW` で上書き可能（backend が 272K に巻き戻った日はこれで下げる）

## 検証

- `zsh -n` 構文チェック
- claude をスタブし、`--model gpt-5.6-sol --settings {"env":{"CLAUDE_CODE_AUTO_COMPACT_WINDOW":"360000"}}` が正しく渡ること、`CLAUDEX_COMPACT_WINDOW` 上書きが効くことを確認
- `--settings`（CLI 引数）が project settings.json を上書きすることは settings.md の precedence（Command-line > Project）で確認。※ nested claude 実行がサンドボックスで禁止のため live 実測は未実施

**未検証**: 実際に claudex セッションで 360K 付近まで伸ばして compact が壁の手前で成功することは、実タスクでの確認が必要。

https://claude.ai/code/session_01NqfvJkL7QkYwXqXvhg5fjB
