### PR TITLE
feat(claudex): claudexf（Codex fast/priority tier 版）を追加

### DIFF
--- a/dot_zsh/functions/claudex.zsh
+++ b/dot_zsh/functions/claudex.zsh
@@ -102,3 +102,11 @@ claudex() {
     ENABLE_TOOL_SEARCH=false \
         command claude --model "$model" --settings "$compact_settings" "$@"
 }
+
+# claudexf: claudex の Codex fast/priority tier 版。
+# -fast サフィックスを claude-code-proxy が service_tier: "priority" に翻訳して upstream に投げる。
+# 速い代わりにサブスク usage の減りが早い。quota を使い切れないとき向け。
+# CLAUDEX_MODEL が明示指定されていればそれを優先する（fast を強制しない）。
+claudexf() {
+    CLAUDEX_MODEL="${CLAUDEX_MODEL:-gpt-5.6-sol-fast[1m]}" claudex "$@"
+}


### PR DESCRIPTION
## Why

claudex（GPT-5.6 Sol）を、Codex の fast/priority tier で叩く `claudexf` が欲しい。quota（サブスク usage）が使い切れず余りがちなので、速い tier を選べるようにする。

## What

`dot_zsh/functions/claudex.zsh` に `claudexf` を追加。既存の `claudex` を再利用し、モデルを `gpt-5.6-sol-fast[1m]` にして起動するだけ。

```sh
claudexf() {
    CLAUDEX_MODEL="${CLAUDEX_MODEL:-gpt-5.6-sol-fast[1m]}" claudex "$@"
}
```

- `-fast` サフィックスを claude-code-proxy が `service_tier: "priority"` に翻訳して upstream に投げる（インストール済みプロキシの `models` に `gpt-5.6-sol-fast` が実在するのを確認済み）
- `[1m]` は claudex と同じく statusline 用。`--settings` の `CLAUDE_CODE_AUTO_COMPACT_WINDOW=360000` ガードもそのまま継承
- `CLAUDEX_MODEL` を明示していればそれを優先（fast を強制しない）
- 追加引数（`--resume` 等）は claudex 経由で透過

トレードオフ: fast/priority tier は速い代わりにサブスク usage の減りが早い。常用ではなく速さが要るときに使う想定。

## 検証

- `zsh -n` 構文チェック
- claude をスタブして確認:
  - `claudexf` → `--model gpt-5.6-sol-fast[1m] --settings {...360000}`、subagent は `gpt-5.6-sol-fast`
  - `claudexf --resume` → 追加引数が末尾に透過
  - `CLAUDEX_MODEL=gpt-5.6-terra[1m] claudexf` → 明示指定を尊重

https://claude.ai/code/session_01NqfvJkL7QkYwXqXvhg5fjB
