### PR TITLE
fix(claudex): small モデルを terra にし claudexf は small も -fast にする

### DIFF
--- a/dot_zsh/functions/claudex.zsh
+++ b/dot_zsh/functions/claudex.zsh
@@ -95,7 +95,7 @@ claudex() {
     # settings.jsonnet の DISABLE_NON_ESSENTIAL_MODEL_CALLS で既に止まっている
     ANTHROPIC_BASE_URL="http://127.0.0.1:${CLAUDEX_PORT:-18765}" \
     ANTHROPIC_AUTH_TOKEN="unused" \
-    ANTHROPIC_SMALL_FAST_MODEL="${CLAUDEX_SMALL_MODEL:-gpt-5.6-luna[1m]}" \
+    ANTHROPIC_SMALL_FAST_MODEL="${CLAUDEX_SMALL_MODEL:-gpt-5.6-terra[1m]}" \
     CLAUDE_CODE_SUBAGENT_MODEL="${model%\[*}" \
     CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=3 \
     CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1 \
@@ -105,8 +105,11 @@ claudex() {
 
 # claudexf: claudex の Codex fast/priority tier 版。
 # -fast サフィックスを claude-code-proxy が service_tier: "priority" に翻訳して upstream に投げる。
+# メインの推論モデルと small/fast モデル（要約・タイトル生成）の両方を fast tier にする。
 # 速い代わりにサブスク usage の減りが早い。quota を使い切れないとき向け。
-# CLAUDEX_MODEL が明示指定されていればそれを優先する（fast を強制しない）。
+# CLAUDEX_MODEL / CLAUDEX_SMALL_MODEL が明示指定されていればそれを優先する（fast を強制しない）。
 claudexf() {
-    CLAUDEX_MODEL="${CLAUDEX_MODEL:-gpt-5.6-sol-fast[1m]}" claudex "$@"
+    CLAUDEX_MODEL="${CLAUDEX_MODEL:-gpt-5.6-sol-fast[1m]}" \
+    CLAUDEX_SMALL_MODEL="${CLAUDEX_SMALL_MODEL:-gpt-5.6-terra-fast[1m]}" \
+        claudex "$@"
 }


### PR DESCRIPTION
## Why

#813（claudexf 追加）の review で「claudexf は `CLAUDEX_MODEL` のみ `-fast` にするが `CLAUDEX_SMALL_MODEL` を設定しないため、small/fast モデルは `gpt-5.6-luna[1m]` の standard tier のまま」と指摘があった。fast tier にするなら small も揃えたい。あわせて small の既定モデルを luna → terra に上げる。

## What

`dot_zsh/functions/claudex.zsh`:

- **claudex**: `ANTHROPIC_SMALL_FAST_MODEL` の既定を `gpt-5.6-luna[1m]` → `gpt-5.6-terra[1m]`
- **claudexf**: `CLAUDEX_MODEL` に加えて `CLAUDEX_SMALL_MODEL` も `-fast` にする（`gpt-5.6-terra-fast[1m]`）。これで要約・タイトル生成の small モデルも priority tier で動く
- どちらも `CLAUDEX_MODEL` / `CLAUDEX_SMALL_MODEL` の明示指定を尊重

`gpt-5.6-terra` / `gpt-5.6-terra-fast` はインストール済みプロキシの `models` に実在を確認済み。

## 検証

- `zsh -n` 構文チェック
- claude をスタブして確認:
  - `claudex` → model `gpt-5.6-sol[1m]` / SMALL `gpt-5.6-terra[1m]`
  - `claudexf` → model `gpt-5.6-sol-fast[1m]` / SMALL `gpt-5.6-terra-fast[1m]`
  - `CLAUDEX_SMALL_MODEL=... claudexf` → 明示指定を尊重

https://claude.ai/code/session_01NqfvJkL7QkYwXqXvhg5fjB
