### PR TITLE
fix(claudex): 公式 model-config docs に合わせて修正（非推奨 env・[1m] 根拠・compact 挙動）

### DIFF
--- a/dot_zsh/functions/claudex.zsh
+++ b/dot_zsh/functions/claudex.zsh
@@ -14,7 +14,7 @@
 #
 # 上書き用の環境変数: CLAUDEX_MODEL, CLAUDEX_SMALL_MODEL, CLAUDEX_PORT, CLAUDEX_COMPACT_WINDOW
 #   例) CLAUDEX_MODEL='gpt-5.6-sol-fast[1m]' claudex    # priority tier で叩く
-#   例) CLAUDEX_MODEL='gpt-5.6-sol' claudex             # [1m] が compact を壊す場合のフォールバック
+#   例) CLAUDEX_COMPACT_WINDOW=250000 claudex           # backend が 272K に巻き戻った日は下げる
 #   例) CLAUDEX_COMPACT_WINDOW=250000 claudex           # backend が 272K に巻き戻った日は下げる
 
 # ポートが listen されているか（外部コマンドに依存せず zsh 組み込みで確認する）
@@ -68,21 +68,21 @@ claudex() {
 
     local model="${CLAUDEX_MODEL:-gpt-5.6-sol[1m]}"
 
-    # [1m] を付けて statusline を /1000k にする。gpt-5.6-sol は claudex が経由する ChatGPT/Codex
-    # バックエンドでは context がキャップされる（実測で ~372K まで到達を確認。OpenAI は 372K で課金が
-    # 想定超だったため Codex default を一時 272K に戻し、数日かけて 372K に戻すとアナウンス:
-    # thsottiaux 2076495156757577895 / openai/codex#31860, #32806）。[1m] を外すと statusline の分母が
-    # モデル既定（~200K）になり、Sol は 200K を超えるためゲージが 100% を振り切って読めなくなる。
-    # 実キャップ 372K に一番近い表示は [1m] の /1000k なので付ける。
+    # [1m] は必須。claudex は ANTHROPIC_BASE_URL が proxy(=LLM gateway) を指すため、CC は 1M サポートを
+    # 検証できず、[1m] を外すと window を 200K として割り当て 200K で auto-compact する
+    # （model-config「拡張コンテキスト」/ Sonnet 5 の項に gateway の挙動として明記）。[1m] で 1M window を
+    # 選ぶことで実キャップ 372K まで使え、statusline も /1000k になる。
     #
-    # auto-compact は下の --settings の CLAUDE_CODE_AUTO_COMPACT_WINDOW（既定 360000）で
-    # 壁の手前 ~331K に焚く。既定は観測済みの 372K キャップに合わせてある。backend が 272K に
-    # 巻き戻った日に "Context limit reached" が再発したら CLAUDEX_COMPACT_WINDOW=250000 で下げる。
+    # gpt-5.6-sol の実キャップ: ChatGPT/Codex backend では ~372K（272K↔372K で揺れる。OpenAI が 372K で
+    # 課金想定超のため Codex default を一時 272K に戻し、数日かけて 372K に戻すとアナウンス:
+    # thsottiaux 2076495156757577895 / openai/codex#31860, #32806）。
     #
-    # 【要実測の前提】[1m]（context 窓 1M と認識）と明示 AUTO_COMPACT_WINDOW=360000 が両立し、
-    # compact が 1M 手前ではなく 360000 基準（~331K）で焚かれること。ドキュメントが曖昧で nested claude
-    # 禁止のため机上検証不可。もし [1m] が AUTO_COMPACT_WINDOW を上書きして 372K で詰むなら、
-    # CLAUDEX_MODEL='gpt-5.6-sol'（[1m] 無し）にフォールバックする。
+    # compact しきい値: [1m] が window を 1M と認識させ、CLAUDE_CODE_AUTO_COMPACT_WINDOW がその中の発火
+    # しきい値を決める（両者は競合せず共存。model-config: Sonnet 5 は 1M window で既定 ~967K しきい値、
+    # 変更は CLAUDE_CODE_AUTO_COMPACT_WINDOW）。この値は「そのトークン数ちょうどで compact」であり、9割
+    # 手前ではない。既定 360000 は 372K の壁の手前 12K で要約に入る想定（要約リクエストは現 context 全量を
+    # 送るのでしきい値 < 実キャップ でないと壁を超えて失敗＝デッドロックする）。backend が 272K に巻き戻った
+    # 日は 360000 では詰むため CLAUDEX_COMPACT_WINDOW=250000 のように下げる。
     #
     # AUTO_COMPACT_WINDOW は OS 環境変数ではなく --settings（CLI 引数）で渡す。settings ファイルの env は
     # OS 環境変数に勝つため、プロジェクトの .claude/settings.json が env.CLAUDE_CODE_AUTO_COMPACT_WINDOW を
@@ -90,12 +90,15 @@ claudex() {
     # なので、--settings で渡せば project 設定にも勝てる（settings.md）。
     local compact_settings="{\"env\":{\"CLAUDE_CODE_AUTO_COMPACT_WINDOW\":\"${CLAUDEX_COMPACT_WINDOW:-360000}\"}}"
 
+    # 要約・タイトル生成等のバックグラウンド機能に使う小モデルは ANTHROPIC_DEFAULT_HAIKU_MODEL で指定する。
+    # 旧 ANTHROPIC_SMALL_FAST_MODEL は非推奨（model-config の環境変数表の注記）。
+    #
     # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC は settings.jsonnet と同様に設定しない
     # （remote-control の eligibility チェックがブロックされるため）。無駄なモデル呼び出し自体は
     # settings.jsonnet の DISABLE_NON_ESSENTIAL_MODEL_CALLS で既に止まっている
     ANTHROPIC_BASE_URL="http://127.0.0.1:${CLAUDEX_PORT:-18765}" \
     ANTHROPIC_AUTH_TOKEN="unused" \
-    ANTHROPIC_SMALL_FAST_MODEL="${CLAUDEX_SMALL_MODEL:-gpt-5.6-terra[1m]}" \
+    ANTHROPIC_DEFAULT_HAIKU_MODEL="${CLAUDEX_SMALL_MODEL:-gpt-5.6-terra[1m]}" \
     CLAUDE_CODE_SUBAGENT_MODEL="${model%\[*}" \
     CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=3 \
     CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1 \

--- a/dot_zsh/functions/claudex.zsh
+++ b/dot_zsh/functions/claudex.zsh
@@ -90,8 +90,13 @@ claudex() {
     # なので、--settings で渡せば project 設定にも勝てる（settings.md）。
     local compact_settings="{\"env\":{\"CLAUDE_CODE_AUTO_COMPACT_WINDOW\":\"${CLAUDEX_COMPACT_WINDOW:-360000}\"}}"
 
-    # 要約・タイトル生成等のバックグラウンド機能に使う小モデルは ANTHROPIC_DEFAULT_HAIKU_MODEL で指定する。
-    # 旧 ANTHROPIC_SMALL_FAST_MODEL は非推奨（model-config の環境変数表の注記）。
+    # メインの推論モデル（--model）以外に、CC が内部で使う haiku / sonnet エイリアスも Codex モデルに
+    # 向けておく。素の Claude 名（claude-haiku-* / claude-sonnet-*）に解決されると proxy 経由で意図しない
+    # モデルになるため、両方 terra 系（CLAUDEX_SMALL_MODEL）にマッピングする。
+    #   - ANTHROPIC_DEFAULT_HAIKU_MODEL: haiku エイリアス＋バックグラウンド機能（要約・タイトル生成等）。
+    #     旧 ANTHROPIC_SMALL_FAST_MODEL は非推奨（model-config の環境変数表の注記）
+    #   - ANTHROPIC_DEFAULT_SONNET_MODEL: sonnet エイリアス（/model sonnet 等）
+    # opus エイリアスは今は未マッピング（primary は --model で sol を明示しているため通常は不要）。
     #
     # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC は settings.jsonnet と同様に設定しない
     # （remote-control の eligibility チェックがブロックされるため）。無駄なモデル呼び出し自体は
@@ -99,6 +104,7 @@ claudex() {
     ANTHROPIC_BASE_URL="http://127.0.0.1:${CLAUDEX_PORT:-18765}" \
     ANTHROPIC_AUTH_TOKEN="unused" \
     ANTHROPIC_DEFAULT_HAIKU_MODEL="${CLAUDEX_SMALL_MODEL:-gpt-5.6-terra[1m]}" \
+    ANTHROPIC_DEFAULT_SONNET_MODEL="${CLAUDEX_SMALL_MODEL:-gpt-5.6-terra[1m]}" \
     CLAUDE_CODE_SUBAGENT_MODEL="${model%\[*}" \
     CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=3 \
     CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1 \

--- a/dot_zsh/functions/claudex.zsh
+++ b/dot_zsh/functions/claudex.zsh
@@ -90,21 +90,22 @@ claudex() {
     # なので、--settings で渡せば project 設定にも勝てる（settings.md）。
     local compact_settings="{\"env\":{\"CLAUDE_CODE_AUTO_COMPACT_WINDOW\":\"${CLAUDEX_COMPACT_WINDOW:-360000}\"}}"
 
-    # メインの推論モデル（--model）以外に、CC が内部で使う haiku / sonnet エイリアスも Codex モデルに
-    # 向けておく。素の Claude 名（claude-haiku-* / claude-sonnet-*）に解決されると proxy 経由で意図しない
-    # モデルになるため、両方 terra 系（CLAUDEX_SMALL_MODEL）にマッピングする。
-    #   - ANTHROPIC_DEFAULT_HAIKU_MODEL: haiku エイリアス＋バックグラウンド機能（要約・タイトル生成等）。
-    #     旧 ANTHROPIC_SMALL_FAST_MODEL は非推奨（model-config の環境変数表の注記）
-    #   - ANTHROPIC_DEFAULT_SONNET_MODEL: sonnet エイリアス（/model sonnet 等）
-    # opus エイリアスは今は未マッピング（primary は --model で sol を明示しているため通常は不要）。
+    # メインの推論モデル（--model）以外に、CC が内部で使う opus / sonnet / haiku エイリアスも Codex モデルに
+    # 向けておく。素の Claude 名（claude-opus-* 等）に解決されると proxy 経由で意図しないモデルになるため
+    # 全部マッピングする。plan mode 常用（default / opus / opusplan は opus 系に解決）なので特に opus が要る。
+    #   - ANTHROPIC_DEFAULT_OPUS_MODEL:   opus エイリアス／plan mode の opusplan（plan フェーズ）→ primary と同じ sol 系
+    #   - ANTHROPIC_DEFAULT_SONNET_MODEL: sonnet エイリアス／opusplan の実行フェーズ → 同じく sol 系（実作業なので flagship）
+    #   - ANTHROPIC_DEFAULT_HAIKU_MODEL:  haiku エイリアス＋バックグラウンド機能（要約・タイトル生成等）→ terra 系
+    #     （旧 ANTHROPIC_SMALL_FAST_MODEL は非推奨: model-config の環境変数表の注記）
     #
     # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC は settings.jsonnet と同様に設定しない
     # （remote-control の eligibility チェックがブロックされるため）。無駄なモデル呼び出し自体は
     # settings.jsonnet の DISABLE_NON_ESSENTIAL_MODEL_CALLS で既に止まっている
     ANTHROPIC_BASE_URL="http://127.0.0.1:${CLAUDEX_PORT:-18765}" \
     ANTHROPIC_AUTH_TOKEN="unused" \
+    ANTHROPIC_DEFAULT_OPUS_MODEL="$model" \
+    ANTHROPIC_DEFAULT_SONNET_MODEL="$model" \
     ANTHROPIC_DEFAULT_HAIKU_MODEL="${CLAUDEX_SMALL_MODEL:-gpt-5.6-terra[1m]}" \
-    ANTHROPIC_DEFAULT_SONNET_MODEL="${CLAUDEX_SMALL_MODEL:-gpt-5.6-terra[1m]}" \
     CLAUDE_CODE_SUBAGENT_MODEL="${model%\[*}" \
     CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=3 \
     CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1 \


### PR DESCRIPTION
## Why

公式ドキュメント [model-config（ja）](https://code.claude.com/docs/ja/model-config) を精読したところ、claudex の実装・コメントに docs と食い違う点が3つ見つかった。これまで実測できず「未検証」としていた挙動が docs で確定したものを含む。

## What

`dot_zsh/functions/claudex.zsh`:

### 1. 非推奨 env の置き換え
小モデル（要約・タイトル生成等のバックグラウンド機能）の指定を `ANTHROPIC_SMALL_FAST_MODEL` → **`ANTHROPIC_DEFAULT_HAIKU_MODEL`** に。docs の環境変数表に「`ANTHROPIC_SMALL_FAST_MODEL` は `ANTHROPIC_DEFAULT_HAIKU_MODEL` の代わりに非推奨」と明記されている。

### 2. \`[1m]\` が必須である根拠を docs で裏付け
docs「拡張コンテキスト / Sonnet 5」項:
> LLM ゲートウェイ：\`ANTHROPIC_BASE_URL\` が ゲートウェイ を指す場合、Claude Code は 1M サポートを検証できません。…代わりにウィンドウが **200K として割り当てられ、その境界で自動コンパクトされます**。

claudex は proxy＝gateway なので、\`[1m]\` を外すと statusline だけでなく **実際に window が 200K に制限される**。\`[1m]\` で 1M window を選ぶことで実キャップ 372K まで使える。#812 で \`[1m]\` を戻した判断がこれで裏付けられた。

### 3. compact 挙動の事実誤認を修正
docs（Sonnet 5）:
> セッションはウィンドウがいっぱいになる前に、デフォルトでは約 967K トークンの時点で自動コンパクトされます。別の**しきい値**を選択するには、\`CLAUDE_CODE_AUTO_COMPACT_WINDOW\` を設定します。

\`CLAUDE_CODE_AUTO_COMPACT_WINDOW\` は「窓サイズ（その9割で発火）」ではなく **そのトークン数ちょうどで発火するしきい値**。旧コメントの「~331K で焚かれる」は誤りで、正しくは **360K ちょうどで compact**（372K の壁の手前 12K で要約に入る）。あわせて \`[1m]\` と \`AUTO_COMPACT_WINDOW\` は競合せず共存する（前者が window を 1M に、後者がしきい値を決める）ことが docs で確定したため、#812 で残した「上書きするか未検証／フォールバック」の留保を削除。

### 4. opus / sonnet / haiku エイリアスを全て Codex モデルにマッピング（追加コミット）
CC が内部で使う3エイリアスを全部 Codex モデルに向け、素の Claude 名（\`claude-opus-*\` 等）に解決されて proxy 経由で意図しないモデルになるのを防ぐ。実作業 tier である **opus / sonnet は primary と同じ sol 系**（\`ANTHROPIC_DEFAULT_OPUS_MODEL\` / \`ANTHROPIC_DEFAULT_SONNET_MODEL\` = \`\$model\`）、背景処理の **haiku のみ terra 系**（\`ANTHROPIC_DEFAULT_HAIKU_MODEL\` = \`CLAUDEX_SMALL_MODEL\`）に据える。plan mode 常用（default / opus / opusplan は opus 系に解決）なので特に opus のマッピングが必須。

## 補足（値の再確認）
既定 360000 は「360K ちょうどで compact」＝ 372K キャップの手前 12K。以前観測した proxy の token カウントのズレを考えると余裕は薄め。安全側に振るなら 340000 前後も選択肢だが、高めを優先する現状の意向に合わせ 360000 を維持。regression（272K）日は \`CLAUDEX_COMPACT_WINDOW=250000\` で下げる運用は据え置き。

## 検証

- \`zsh -n\` 構文チェック
- claude をスタブして確認:
  - \`claudex\` → OPUS/SONNET \`gpt-5.6-sol[1m]\`、HAIKU \`gpt-5.6-terra[1m]\`、model \`gpt-5.6-sol[1m]\`（旧 \`ANTHROPIC_SMALL_FAST_MODEL\` は未設定）
  - \`claudexf\` → OPUS/SONNET \`gpt-5.6-sol-fast[1m]\`、HAIKU \`gpt-5.6-terra-fast[1m]\`、model \`gpt-5.6-sol-fast[1m]\`

https://claude.ai/code/session_01NqfvJkL7QkYwXqXvhg5fjB