### PR TITLE
feat(gwc): --ccxf オプションを追加（claudexf を worktree 起動）

### DIFF
--- a/dot_zsh/functions/git-worktree.zsh
+++ b/dot_zsh/functions/git-worktree.zsh
@@ -207,6 +207,7 @@ gwr() {
 #   gwc ENG-123 --cco                # 作成後に claude --model opus を初期プロンプトで起動
 #   gwc ENG-123 --ccs                # 作成後に claude --model sonnet を初期プロンプトで起動
 #   gwc ENG-123 --ccx                # 作成後に claudex（Claude Code のハーネス + GPT-5.6 Sol）を初期プロンプトで起動
+#   gwc ENG-123 --ccxf               # 作成後に claudexf（claudex の Codex fast/priority tier 版）を初期プロンプトで起動
 #   gwc ENG-123 --co                 # 作成後に codex を初期プロンプトで起動（GWC_CODEX_CLI_INITIAL_PROMPT）
 #   gwc ENG-123 --cc "追加の指示"     # 初期プロンプト + 改行2つ + 追加プロンプトで起動（ref より後ろに置くこと）
 #   gwc ENG-123 --ccco               # cmux 限定: claude を現在ペイン、codex を右 split で同時起動
@@ -214,7 +215,7 @@ gwr() {
 #   export GWC_COPY_FILES=".env.test,config.local.json"  # 環境変数で事前設定
 #   export GWC_PNPM_EXTRA_DIRS="apps/foo,apps/bar"  # root 以外で pnpm install するディレクトリ（worktree root からの相対パス、カンマ区切り）
 #   export GWC_LINEAR_API_KEY="lin_api_..."  # Linear モードに必要（環境変数として設定）
-#   export GWC_CLAUDE_CODE_INITIAL_PROMPT="..."  # --cc / --ccx で claude / claudex に渡す初期プロンプト（未設定なら素の起動 or 追加プロンプトのみ）
+#   export GWC_CLAUDE_CODE_INITIAL_PROMPT="..."  # --cc / --ccx / --ccxf で claude / claudex(f) に渡す初期プロンプト（未設定なら素の起動 or 追加プロンプトのみ）
 #   export GWC_CODEX_CLI_INITIAL_PROMPT="..."    # --co で codex に渡す初期プロンプト（同上）
 #
 # cmux 環境（CMUX_WORKSPACE_ID あり）で Linear/PR モードを使うと、実行元の cmux
@@ -235,9 +236,9 @@ gwc() {
     local skip_fzf=false
     local open_with_cursor=false
     local cmux_title=""  # cmux 環境ならワークスペース名に設定する文字列（Linear/PR モードでセット）
-    local launch_agent=""  # --cc → claude / --ccx → claudex / --co → codex / --ccco → claude（前面）。worktree 作成後に初期プロンプトで起動
+    local launch_agent=""  # --cc → claude / --ccx → claudex / --ccxf → claudexf / --co → codex / --ccco → claude（前面）。worktree 作成後に初期プロンプトで起動
     local launch_model=""  # --ccf → fable / --cco → opus / --ccs → sonnet。claude 起動時だけ --model として渡す
-                           # （--ccx は claudex 側が --model を指定するため空のままにする）
+                           # （--ccx / --ccxf は claudex(f) 側が --model を指定するため空のままにする）
     local split_agent=""   # --ccco → codex を右 split で起動（claude は launch_agent で現在ペイン前面起動）
     local agent_extra=""   # --cc / --co / --ccco の後ろに渡された追加プロンプト
 
@@ -299,7 +300,7 @@ gwc() {
             # 直後にオプションでないトークンがあれば追加プロンプトとして取り込む
             # （例: gwc ENG-123 --cc "追加の指示"）。ref と紛れないよう --cc/--co は ref の後ろに置くこと。
             if [ -n "$launch_agent" ] || [ -n "$split_agent" ]; then
-                echo "エラー: --cc / --ccf / --cco / --ccs / --ccx / --co / --ccco は同時に指定できません。" >&2
+                echo "エラー: --cc / --ccf / --cco / --ccs / --ccx / --ccxf / --co / --ccco は同時に指定できません。" >&2
                 return 1
             fi
             if [ "$1" = "--cc" ]; then
@@ -315,7 +316,7 @@ gwc() {
             ;;
         --ccf | --cco | --ccs)
             if [ -n "$launch_agent" ] || [ -n "$split_agent" ]; then
-                echo "エラー: --cc / --ccf / --cco / --ccs / --ccx / --co / --ccco は同時に指定できません。" >&2
+                echo "エラー: --cc / --ccf / --cco / --ccs / --ccx / --ccxf / --co / --ccco は同時に指定できません。" >&2
                 return 1
             fi
             launch_agent="claude"
@@ -332,15 +333,20 @@ gwc() {
                 shift # 追加プロンプトを消費
             fi
             ;;
-        --ccx)
+        --ccx | --ccxf)
             # Claude Code のハーネスを GPT-5.6 Sol で駆動する claudex を起動する。
-            # claudex 自身が --model を指定するため launch_model は空のままにする。
+            # --ccxf は Codex fast/priority tier 版の claudexf。
+            # claudex/claudexf 自身が --model を指定するため launch_model は空のままにする。
             if [ -n "$launch_agent" ] || [ -n "$split_agent" ]; then
-                echo "エラー: --cc / --ccf / --cco / --ccs / --ccx / --co / --ccco は同時に指定できません。" >&2
+                echo "エラー: --cc / --ccf / --cco / --ccs / --ccx / --ccxf / --co / --ccco は同時に指定できません。" >&2
                 return 1
             fi
-            launch_agent="claudex"
-            shift # --ccx を消費
+            if [ "$1" = "--ccxf" ]; then
+                launch_agent="claudexf"
+            else
+                launch_agent="claudex"
+            fi
+            shift # --ccx / --ccxf を消費
             if [ -n "$1" ] && [[ "$1" != -* ]]; then
                 agent_extra="$1"
                 shift # 追加プロンプトを消費
@@ -350,7 +356,7 @@ gwc() {
             # cmux 限定: claude を現在ペイン前面、codex を右 split で同時起動する。
             # 末尾に非オプションのトークンがあれば両エージェント共通の追加プロンプトとして取り込む。
             if [ -n "$launch_agent" ] || [ -n "$split_agent" ]; then
-                echo "エラー: --cc / --ccf / --cco / --ccs / --ccx / --co / --ccco は同時に指定できません。" >&2
+                echo "エラー: --cc / --ccf / --cco / --ccs / --ccx / --ccxf / --co / --ccco は同時に指定できません。" >&2
                 return 1
             fi
             # validation を最初に: cmux 環境でなければここで弾く（worktree を作らない）
@@ -715,7 +721,7 @@ gwc() {
         fi
         # ★★★ ここまで ★★★
 
-        # --cc / --ccx / --co: worktree 内で claude / claudex / codex を初期プロンプト付きで起動する。
+        # --cc / --ccx / --ccxf / --co: worktree 内で claude / claudex / claudexf / codex を初期プロンプト付きで起動する。
         # プロンプトは位置引数で渡す（codex は stdin パイプ非対応のため。claude も同様に統一）。
         #   - 環境変数（GWC_CLAUDE_CODE_INITIAL_PROMPT / GWC_CODEX_CLI_INITIAL_PROMPT）と
         #     追加プロンプト（agent_extra）の両方があれば「環境変数 + 改行2つ + 追加」を送る
@@ -780,8 +786,8 @@ gwc() {
                 echo "警告: '$launch_agent' コマンドが見つかりません。起動をスキップします。" >&2
             else
                 local agent_base=""
-                # claudex は Claude Code のハーネスなので claude と同じ初期プロンプトを使う
-                if [ "$launch_agent" = "claude" ] || [ "$launch_agent" = "claudex" ]; then
+                # claudex / claudexf は Claude Code のハーネスなので claude と同じ初期プロンプトを使う
+                if [ "$launch_agent" = "claude" ] || [ "$launch_agent" = "claudex" ] || [ "$launch_agent" = "claudexf" ]; then
                     agent_base="$GWC_CLAUDE_CODE_INITIAL_PROMPT"
                 else
                     agent_base="$GWC_CODEX_CLI_INITIAL_PROMPT"


### PR DESCRIPTION
## Why

`gwc` には `--ccx`（claudex = Claude Code のハーネス + GPT-5.6 Sol）を worktree 作成後に起動するオプションがあるが、Codex fast/priority tier 版の `claudexf` を起動する手段が無かった。最近サブスク quota を使い切れず reset している状況では、速い fast tier を worktree からワンショットで起動できると便利なため追加する。

## What

`dot_zsh/functions/git-worktree.zsh`:

- `--ccxf` オプションを追加。`--ccx` の case を `--ccx | --ccxf` に拡張し、`--ccxf` のとき `launch_agent="claudexf"` にする。`claudex` 同様 `--model` は `claudexf` 側に委ねるため `launch_model` は空のまま。
- 既存の起動経路（`command -v "$launch_agent"` → `"$launch_agent" ...`）にそのまま乗るため、起動ロジックの追加変更は不要。
- 初期プロンプト判定を `claude` / `claudex` と同じ扱いに（`claudexf` も Claude Code のハーネスなので `GWC_CLAUDE_CODE_INITIAL_PROMPT` を使う）。
- 相互排他エラーメッセージ・使用例コメント・`launch_agent` 説明コメント・`GWC_CLAUDE_CODE_INITIAL_PROMPT` の doc コメントを `--ccxf` 込みに更新。

## 検証

- `zsh -n` 構文チェック
- case 分岐の再現テスト: `--ccx → claudex` / `--ccxf → claudexf`

https://claude.ai/code/session_01NqfvJkL7QkYwXqXvhg5fjB