### PR TITLE
fix(claudex): compaction の余裕を広げる

### DIFF
--- a/dot_zsh/functions/claudex.zsh
+++ b/dot_zsh/functions/claudex.zsh
@@ -15,7 +15,6 @@
 # 上書き用の環境変数: CLAUDEX_MODEL, CLAUDEX_SMALL_MODEL, CLAUDEX_PORT, CLAUDEX_COMPACT_WINDOW
 #   例) CLAUDEX_MODEL='gpt-5.6-sol-fast[1m]' claudex    # priority tier で叩く
 #   例) CLAUDEX_COMPACT_WINDOW=250000 claudex           # backend が 272K に巻き戻った日は下げる
-#   例) CLAUDEX_COMPACT_WINDOW=250000 claudex           # backend が 272K に巻き戻った日は下げる
 
 # ポートが listen されているか（外部コマンドに依存せず zsh 組み込みで確認する）
 _claudex_port_open() {
@@ -77,18 +76,16 @@ claudex() {
     # 課金想定超のため Codex default を一時 272K に戻し、数日かけて 372K に戻すとアナウンス:
     # thsottiaux 2076495156757577895 / openai/codex#31860, #32806）。
     #
-    # compact しきい値: [1m] が window を 1M と認識させ、CLAUDE_CODE_AUTO_COMPACT_WINDOW がその中の発火
-    # しきい値を決める（両者は競合せず共存。model-config: Sonnet 5 は 1M window で既定 ~967K しきい値、
-    # 変更は CLAUDE_CODE_AUTO_COMPACT_WINDOW）。この値は「そのトークン数ちょうどで compact」であり、9割
-    # 手前ではない。既定 360000 は 372K の壁の手前 12K で要約に入る想定（要約リクエストは現 context 全量を
-    # 送るのでしきい値 < 実キャップ でないと壁を超えて失敗＝デッドロックする）。backend が 272K に巻き戻った
-    # 日は 360000 では詰むため CLAUDEX_COMPACT_WINDOW=250000 のように下げる。
+    # compact 計算用の容量: [1m] が window を 1M と認識させ、CLAUDE_CODE_AUTO_COMPACT_WINDOW が
+    # auto-compact の計算に使う容量を上書きする（両者は競合せず共存）。これは物理的な context 上限や厳密な
+    # 発火トークン数ではない。既定 340000 は観測済みの 372K キャップに対して計算上 32K の余裕を確保する。
+    # backend が 272K に巻き戻った日は 340000 でも詰むため CLAUDEX_COMPACT_WINDOW=250000 のように下げる。
     #
     # AUTO_COMPACT_WINDOW は OS 環境変数ではなく --settings（CLI 引数）で渡す。settings ファイルの env は
     # OS 環境変数に勝つため、プロジェクトの .claude/settings.json が env.CLAUDE_CODE_AUTO_COMPACT_WINDOW を
     # 設定していると OS env 注入では負ける。優先順位は Managed > Command-line > Local > Project > User
     # なので、--settings で渡せば project 設定にも勝てる（settings.md）。
-    local compact_settings="{\"env\":{\"CLAUDE_CODE_AUTO_COMPACT_WINDOW\":\"${CLAUDEX_COMPACT_WINDOW:-360000}\"}}"
+    local compact_settings="{\"env\":{\"CLAUDE_CODE_AUTO_COMPACT_WINDOW\":\"${CLAUDEX_COMPACT_WINDOW:-340000}\"}}"
 
     # メインの推論モデル（--model）以外に、CC が内部で使う opus / sonnet / haiku エイリアスも Codex モデルに
     # 向けておく。素の Claude 名（claude-opus-* 等）に解決されると proxy 経由で意図しないモデルになるため


### PR DESCRIPTION
## Why

claudex / claudexf の auto-compaction が、観測済みの約372Kコンテキスト上限に対して12Kしか余裕を持たず、要約処理が間に合わず停止することがあるため。

## What

- `CLAUDE_CODE_AUTO_COMPACT_WINDOW` の既定値を `360000` から `340000` に下げ、計算上の余裕を12Kから32Kへ拡大
- 現行のClaude Code公式仕様に合わせ、この変数を「厳密な発火トークン数」ではなく「auto-compactionの計算に使う容量」と説明するようコメントを修正
- 重複していた上書き例を削除

検証: `zsh -n dot_zsh/functions/claudex.zsh`、`git diff --check`
