### PR TITLE
fix: permission allow ルールの Write(.codex-reviews/*) を Edit に変更

### DIFF
--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -67,7 +67,7 @@ local autoModeRules = import 'auto-mode.libsonnet';
       'Bash(codex exec *)',
       'Bash(codex-review-exec *)',
       'Read(.codex-reviews/*)',
-      'Write(.codex-reviews/*)',
+      'Edit(.codex-reviews/*)',
       'Bash(lsof *)',
       'Bash(awk *)',
       'Bash(sed *)',


### PR DESCRIPTION
## Why

Claude Code の起動の度に以下の警告が表示されていた。

```
Permission allow rule (../../../../.claude/settings.json): Write(.codex-reviews/*) is not matched by file permission checks — only Edit(path) rules are. Use Edit(.codex-reviews/*) instead (Edit rules cover all file-editing tools).
```

Claude Code のファイル permission チェックは `Edit(path)` 形式のルールのみを参照するため、`Write(path)` 形式の allow ルールはマッチせず、実質的に効いていなかった。

## What

- `dot_claude/settings.jsonnet` の permissions.allow から `Write(.codex-reviews/*)` を `Edit(.codex-reviews/*)` に変更（警告メッセージの指示通り。Edit ルールは Write を含む全ファイル編集ツールをカバーする）
- `dot_claude/agents/codex-review.md` の frontmatter にある `Write(.codex-reviews/*)` はエージェントが使用可能なツールの宣言であり、settings.json の permission ルールとは別物（警告の対象外）のため変更しない

(by Claude Code)

https://claude.ai/code/session_01H5SrjiftcuheqZ6U386DGG