### PR TITLE
chore: subagent の同時実行上限と nested spawn 制限を緩和

### DIFF
--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -278,6 +278,11 @@ local autoModeRules = import 'auto-mode.libsonnet';
     DISABLE_ERROR_REPORTING: '1',
     DISABLE_NON_ESSENTIAL_MODEL_CALLS: '1',
     CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR: '1',
+    // 2.1.217 で subagent に 2 つの上限が入った。どちらも既定値は運用に合わないため緩和する。
+    // - 同時実行数の上限（既定 20）。大規模な fan-out を潰さないよう引き上げる
+    // - subagent からの nested spawn 禁止（既定は深さ 1 相当）。ネスト委譲を常用するため許可する
+    CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS: '100',
+    CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH: '5',
     // 実験的 Agent Teams は無効化する。teammate（subagent）の permission request が
     // PermissionRequest hook を経由せず端末の手動プロンプトに直行し、ccgate による許可判定が
     // バイパスされる既知バグ（anthropics/claude-code#23983, open）があるため。


### PR DESCRIPTION
## Why

claude-code 2.1.217（#831 で導入予定）で subagent に 2 つの制限が入る。

- 同時実行 subagent 数に上限（既定 20、`CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` で上書き可）
- subagent が nested subagent を spawn しなくなった（`CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` で深いネストを許可可能）

どちらも既定のままだと従来の運用（大きな fan-out・subagent からのさらなる委譲）を壊すため、明示的に緩和する。

## What

`dot_claude/settings.jsonnet` の `env` に以下を追加。

- `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS: '100'`
- `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH: '5'`

(by Claude Code)

https://claude.ai/code/session_01Ca8FQygaysqsqip244Zrpx
