### PR TITLE
fix: subagent の isolation: worktree 起動を deny

### DIFF
--- a/dot_claude/permission-rules.libsonnet
+++ b/dot_claude/permission-rules.libsonnet
@@ -44,6 +44,18 @@ local rules = [
     reason: 'git worktree の操作は禁止です。worktree の管理はユーザーが行います。',
   },
   {
+    // subagent を isolation: worktree で起動する経路を禁止する。Bash(git worktree*) は
+    // シェル経由の git worktree コマンドしか止められず、Agent/Task ツールが内部で worktree を
+    // 作る経路（isolation: 'worktree'）を素通りさせていたため、意図せず worktree で agent が
+    // 起動されるインシデントが発生した。worktree の管理はユーザーが行う方針に合わせ、
+    // subagent の worktree 隔離だけをピンポイントで deny する（ユーザーの `claude --worktree` や
+    // EnterWorktree は影響を受けない）。
+    // ref: https://code.claude.com/docs/en/permissions#match-by-input-parameter
+    matcher: 'Agent',
+    spec: 'Agent(isolation:worktree)',
+    reason: 'subagent を isolation: worktree で起動することは禁止です。worktree の管理はユーザーが行います。isolation を外して起動してください。',
+  },
+  {
     matcher: 'Bash',
     spec: 'Bash(git merge*--squash*)',
     reason: 'git merge --squash は禁止です。',


### PR DESCRIPTION
## Why

subagent が `isolation: 'worktree'` で起動され、意図せず git worktree 上で agent が動くインシデントが発生した。

既存の `Bash(git worktree*)` deny はシェル経由の `git worktree` コマンドしか止められず、Agent/Task ツールが内部で worktree を作る `isolation: 'worktree'` 経路は素通りしていた。

worktree の管理はユーザーが行う方針なので、subagent の worktree 隔離だけをピンポイントで禁止する。`WorktreeCreate` hook を `exit 1` にする案はユーザー自身の `claude --worktree` まで潰すため採らない。

公式に `Agent(isolation:worktree)` という input parameter マッチの deny ルールが用意されている（[Permissions: Match by input parameter](https://code.claude.com/docs/en/permissions#match-by-input-parameter)）ことを確認済み。

## What

`dot_claude/permission-rules.libsonnet` の `rules` に以下を追加。`permissions.deny`（本体）と PreToolUse の additionalContext hint の両方に反映される。

- `Agent(isolation:worktree)` を deny

ユーザーの `claude --worktree` / `EnterWorktree` は影響を受けない。

(by Claude Code)

https://claude.ai/code/session_01Ca8FQygaysqsqip244Zrpx

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/dotfiles/pull/835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->