### PR TITLE
fix: worktree 操作を一切禁止（EnterWorktree も deny）

### DIFF
--- a/dot_claude/permission-rules.libsonnet
+++ b/dot_claude/permission-rules.libsonnet
@@ -56,6 +56,15 @@ local rules = [
     reason: 'subagent を isolation: worktree で起動することは禁止です。worktree の管理はユーザーが行います。isolation を外して起動してください。',
   },
   {
+    // Claude がセッション内でその場に worktree を作って入る EnterWorktree ツールを禁止する。
+    // 「work in a worktree」等で worktree に移動する経路。worktree の管理はユーザーが行う方針に
+    // 従い、worktree 操作は一切禁止する。ExitWorktree（worktree から抜ける／後始末）は逃げ道
+    // として残す。
+    matcher: 'EnterWorktree',
+    spec: 'EnterWorktree',
+    reason: 'worktree の操作は一切禁止です。worktree の作成・移動はユーザーが行います。現在の作業ディレクトリのまま作業してください。',
+  },
+  {
     matcher: 'Bash',
     spec: 'Bash(git merge*--squash*)',
     reason: 'git merge --squash は禁止です。',


### PR DESCRIPTION
## Why

#835 で `Agent(isolation:worktree)` を deny したが、worktree 操作を一切禁止したい。

Claude がセッション内で行える worktree 操作は次の3つ。#835 までで 1・2 は塞いだが、3 が残っていた。

1. `Bash(git worktree*)` — シェル経由の git worktree コマンド（既存）
2. `Agent(isolation:worktree)` — subagent の worktree 隔離（#835）
3. `EnterWorktree` — Claude が「work in a worktree」等でその場に worktree を作って入るツール ← 本 PR で追加

## What

`dot_claude/permission-rules.libsonnet` の `rules` に `EnterWorktree` の deny を追加。これで Claude がセッション内で行える worktree 操作を全面禁止する。

`ExitWorktree`（worktree から抜ける／後始末）は、万一 worktree に入ったセッションが抜けられなくなるのを防ぐため逃げ道として残す。ユーザー自身の `claude --worktree` も影響を受けない。

(by Claude Code)

https://claude.ai/code/session_01Ca8FQygaysqsqip244Zrpx
