### PR TITLE
feat: defuddle を導入し WebFetch のモデル要約劣化を回避

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -50,6 +50,12 @@ Think in English, interact with the user in Japanese.
 - 確信が持てない場合は context7・deepwiki 等の MCP・web search・ドキュメント直接参照等で一次ソースの裏付けを取ること
 - 裏付けが取れなかった場合は「未確認」と明記すること
 
+## Web ページ本文の取得
+
+- `WebFetch` は取得本文を小型モデル（reported: Haiku）で要約してからメインモデルに返すため、**通常の HTML ページでは本文が要約・改変されて忠実さが落ちる**。ページ本文を忠実に全文読み込みたいときは、`WebFetch` ではなく `defuddle parse <url> --md` を使う（モデルを挟まず clean な Markdown が返る）。
+- ただし `WebFetch` は、レスポンスが既に markdown（`text/markdown` かつ ~100K 文字未満。約80の信頼ドメインが典型）の場合はモデルを通さず原文をそのまま返す。そのケースは劣化しないので `WebFetch` のままでよい。軽い事実確認・ピンポイント Q&A も同様。全面置き換えではなく、モデル要約で困るときだけ defuddle に寄せる。
+- `defuddle` は静的 HTML をパースするため、JS レンダリング必須の SPA では本文が取れない。その場合は `WebFetch` / claude-in-chrome にフォールバックする。
+
 ## 各種一時的ファイルの出力ディレクトリ
 
 一時的なファイルの出力先として `z` ディレクトリが使える（`.config/git/ignore` により ignore 済み）。

--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -82,6 +82,8 @@ local autoModeRules = import 'auto-mode.libsonnet';
       'Bash(find *)',
       'Bash(grep *)',
       'Bash(rg *)',
+      // Web ページ本文を WebFetch のモデル要約を挟まず clean な Markdown で取得（読み取り専用）
+      'Bash(defuddle parse:*)',
       'Fetch(https://*)',
       // 'WebFetch(https://*)',
       'Bash(pnpm *)',

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -118,3 +118,4 @@ go = "1.26.5"
 "npm:cc-sdd" = "3.0.2"
 "npm:difit" = "5.0.8"
 "npm:@fission-ai/openspec" = "1.6.0"
+"npm:defuddle" = "0.19.2"                                  # WebFetch の代替: URL 本文をモデル要約を挟まず clean な Markdown で取得

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -1735,6 +1735,10 @@ backend = "npm:cc-sdd"
 version = "20.0.17"
 backend = "npm:ccusage"
 
+[[tools."npm:defuddle"]]
+version = "0.19.2"
+backend = "npm:defuddle"
+
 [[tools."npm:difit"]]
 version = "5.0.8"
 backend = "npm:difit"


### PR DESCRIPTION
## Why

Claude Code の組み込み `WebFetch` は、取得したページ本文を小型モデル（公式表記は "small, fast model"、reported: Haiku）で要約してからメインモデルに返す。このため**通常の HTML ページでは本文が要約・改変され、忠実さが落ちる**（＝「アホになる」）。`WebFetch` は組み込みツールで内部モデルを差し替えられないため、本文を忠実に読み込みたいケースには代替手段が要る。

なお `WebFetch` は常にモデルを通すわけではなく、レスポンスが既に markdown（`Content-Type: text/markdown` かつ ~100K 文字未満。約80のハードコード信頼ドメインが典型）の場合はモデルをバイパスして原文をそのまま返す（この閾値・スキップ条件・Haiku というモデル名は公式非公開のリバースエンジニアリング情報。公式ドキュメントは "small, fast model" とのみ明記）。つまり劣化するのは通常 HTML ページのケースで、そこだけ defuddle に寄せれば十分。

kepano/defuddle（記事本文抽出ライブラリ）の CLI `defuddle parse <url> --md` を使えば、モデルを挟まず clean な Markdown が stdout に返り、本文全文がそのままメインモデルのコンテキストに入る。

## What

- **`dot_config/mise/config.toml`**: npm グローバルに `"npm:defuddle" = "0.19.2"` を追加（exact pin、Renovate 自動更新に乗せる）。`defuddle-cli` は deprecated で本体 `defuddle` に統合済みのため本体を導入（`defuddle` コマンドを提供）。ヘッドレスブラウザ不要。
- **`dot_claude/settings.jsonnet`**: allow リストに `Bash(defuddle parse:*)` を追加（読み取り専用コマンドなので都度確認なしで実行可能に）。
- **`dot_claude/CLAUDE.md`**: 「Web ページ本文の取得」セクションを追記。通常 HTML はモデル要約で劣化するため `defuddle parse <url> --md` を優先、markdown/信頼ドメインで原文が返るケースや軽い Q&A は `WebFetch` のまま、という**条件付き**誘導（全面置き換えではない）。JS 必須 SPA は defuddle で取れないため `WebFetch` / claude-in-chrome にフォールバック。

## メモ

- `settings.jsonnet` は `jsonnet` で構文エラーなくコンパイルできることを確認済み。
- 手元での `defuddle parse` 実行検証は、`npx` がポリシーで禁止のため未実施。remote main が single source of truth のため、実機で `chezmoi update` 後に確認する。
- リスク: aube（mise の npm installer）の `trustPolicy=no-downgrade` ガードが defuddle の transitive dep を弾く可能性がある（freee 移行時の tinyexec と同種）。`mise install` が `ERR_AUBE_TRUST_DOWNGRADE` で失敗したら、`[env]` の `NPM_CONFIG_TRUST_POLICY_EXCLUDE` に該当バージョンを追記して対処する。

https://claude.ai/code/session_011UnypUphBF2nQ8iEQYS8we