### PR TITLE
chore: デフォルトモデルを Opus 5 に切り替え

### DIFF
--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -227,11 +227,7 @@ local autoModeRules = import 'auto-mode.libsonnet';
   // CC 2.1.186 で入った plan-mode read-only auto-allow 挙動への対処。
   // 未設定（デフォルト）は true 扱い（cBr() の `!== false` 判定）のため、明示的に false にする必要がある。
   useAutoModeDuringPlan: false,
-  // model: 'claude-opus-4-1-20250805',
-  // model: 'claude-opus-4-6',
-  // model: 'claude-opus-4-6[1m]',
-  // model: 'claude-opus-4-7[1m]',
-  model: 'claude-opus-4-8[1m]',
+  model: 'claude-opus-5[1m]',
   // model: 'opus',
 
   // 無効らしい


### PR DESCRIPTION
## Why

Opus 5 がリリースされたため、素の `claude`（Opus）のデフォルトを Opus 5 に上げる。Opus 4.8 と同価格（$5/$25）・同 1M context のまま、agentic coding と長期タスクが強化された上位版。

## What

- `dot_claude/settings.jsonnet` のデフォルト `model` を `claude-opus-4-8[1m]` → `claude-opus-5[1m]` に変更。
- 併せて溜まっていた旧モデルの `model` コメントアウト履歴を削除。

claudex（外部 GPT-5.6 Sol）は無関係で変更なし。`opus` エイリアス経由（`git-worktree` の `--cco` 等）は最新 Opus に自動追従するため変更不要。

### apply 後の確認

`[1m]` サフィックスを CC 2.1.220 が Opus 5 で受理し 1M context が有効になるか未確認。`chezmoi update` 後に新規セッションの `/status`（`/context`）でモデルと context を確認し、1M が効かない場合は bare の `claude-opus-5` にフォールバックする。

(by Claude Code)