### PR TITLE
chore: language 設定を復帰し Opus 4.8 向けの回避策を解除

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -2,10 +2,6 @@
 
 プロジェクト横断のユーザー指示です。
 
-## 言語
-
-Think in English, interact with the user in Japanese.
-
 ## MCP の使用（必須）
 
 ### 検索・情報取得

--- a/dot_claude/settings.jsonnet
+++ b/dot_claude/settings.jsonnet
@@ -2,9 +2,7 @@ local permissionRules = import 'permission-rules.libsonnet';
 local autoModeRules = import 'auto-mode.libsonnet';
 
 {
-  // 【一時的】language 強制が思考まで日本語化する不具合の回避（claude-code#62123, #63875）。
-  // 言語制御は CLAUDE.md の「言語」セクションに委譲。問題なければ削除/復帰を判断する。
-  // language: 'japanese',
+  language: 'japanese',
   plansDirectory: '.claude/plans',
   // ccusage が読む ~/.claude/projects/**/*.jsonl の自動削除を実質無効化（デフォルト30日 → 10年）。
   // 過去の利用量集計が日々消えないようにするため。0 は無効値なので大きい値を指定する。


### PR DESCRIPTION
## Why

`language: 'japanese'` の無効化と CLAUDE.md「言語」セクションの追加は、Opus 4.8 の tool-call parse 不具合（`The model's tool call could not be parsed`）への回避策としてセットで入れたもの。language 指定をやめて出力だけ日本語にすると、tool call 引数に非 ASCII が乗らなくなり発生が止まる、という日本語/中国語環境で知られた対処。

デフォルトモデルを Opus 5 に切り替えたため、この前提が解消した見込み。upstream の実測（transcript スキャン）では該当の malformed-retry は Opus 4.8 に集中しており、Opus 4.7 は 23k 超のアシスタントメッセージで 0 件、Fable 5・Sonnet 4.6 も 0 件と報告されている。Opus 5 の直接データはまだ無いが、この不具合はエラーが画面に出るので、発生すれば即座に分かる。再発したら本 PR を revert すれば戻せる。

なお過去にこの復帰を行った PR 708 は、Fable 5 のアクセス問題を理由とした revert（PR 719）の巻き添えで戻されたもので、language 側が問題を起こした記録はない。

## What

- `dot_claude/settings.jsonnet`: 暫定コメントを削除し `language: 'japanese'` を復帰
- `dot_claude/CLAUDE.md`: 代替として置いていた「## 言語」セクションを削除（language 強制と競合するため）

反映は merge 後にターゲット環境で `chezmoi update`（`run_onchange_after_40-generate-jsonnet.sh.tmpl` が `~/.claude/settings.json` を再生成）。

### 確認

しばらく通常利用し、`The model's tool call could not be parsed (retry also failed)` が出ないことを確認する。出るようなら revert。

(by Claude Code)