### PR TITLE
fix: プラグイン setup で marketplace clone を update し、失敗を WARN に丸めない

### DIFF
--- a/run_onchange_after_50-claude-plugins.sh.tmpl
+++ b/run_onchange_after_50-claude-plugins.sh.tmpl
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # {{ include ".claude-plugin/marketplace.json" | sha256sum }}
 # {{ include "claude-plugins/aws-knowledge/.claude-plugin/plugin.json" | sha256sum }}
 # {{ include "claude-plugins/aws-knowledge/.mcp.json" | sha256sum }}
@@ -6,8 +7,13 @@
 # {{ include "claude-plugins/gopls-lazy/.lsp.json" | sha256sum }}
 # {{ include "claude-plugins/context7/.claude-plugin/plugin.json" | sha256sum }}
 # {{ include "claude-plugins/context7/.mcp.json" | sha256sum }}
-# プラグイン定義が変更された時に marketplace update + plugin install を実行する
-# 注: gopls-lazy はデフォルト無効（必要なプロジェクトで個別有効化）のため install ループには含めない
+# プラグイン定義が変更された時に marketplace の登録・更新と plugin install を実行する
+# 注: gopls-lazy / freee はデフォルト無効（必要なときに個別有効化）のため install ループには含めない
+#
+# 失敗は WARN に丸めず異常終了させる。run_onchange スクリプトが非ゼロで終わると chezmoi は
+# 実行状態を記録しないため（TargetStateScript.Apply が RunScript のエラー時に PersistentStateSet
+# の前で return する）、次の chezmoi apply で自動的に再試行される。WARN に丸めて exit 0 すると
+# 「成功」として記録され、スクリプト内容が変わるまで二度と再試行されない。
 
 {{ template "path-setup.tmpl" . }}
 
@@ -20,12 +26,11 @@ echo "Claude Code プラグインを更新中..."
 # settings.json の extraKnownMarketplaces 宣言だけでは、非対話 CLI 用の状態ファイル
 # （~/.claude/plugins/known_marketplaces.json）にマーケットプレイスが登録されない。
 # 明示的に add して登録する（未登録なら clone、登録済みなら何もしない）。
-claude plugin marketplace add tak848/dotfiles || echo "WARN: marketplace add failed" >&2
-# add は登録済みの marketplace を更新しない（"already on disk" で終了する）ため、
-# ~/.claude/plugins/marketplaces/tak848-plugins の clone が古いまま残り、
-# 新しく追加したプラグインが install 時に "not found in marketplace" になる。
-# 明示的に update して clone を最新にする。
-claude plugin marketplace update tak848-plugins || echo "WARN: marketplace update failed" >&2
+claude plugin marketplace add tak848/dotfiles
+# add は登録済みの marketplace の clone を更新しない（"already on disk" で終了する）ため、
+# ~/.claude/plugins/marketplaces/tak848-plugins が古いまま残り、新しく追加したプラグインが
+# install 時に "not found in marketplace" になる。明示的に update して clone を最新にする。
+claude plugin marketplace update tak848-plugins
 for plugin in aws-knowledge context7; do
-    claude plugin install "${plugin}@tak848-plugins" || echo "WARN: plugin install failed: ${plugin}" >&2
+    claude plugin install "${plugin}@tak848-plugins"
 done

--- a/run_onchange_after_50-claude-plugins.sh.tmpl
+++ b/run_onchange_after_50-claude-plugins.sh.tmpl
@@ -19,8 +19,13 @@ fi
 echo "Claude Code プラグインを更新中..."
 # settings.json の extraKnownMarketplaces 宣言だけでは、非対話 CLI 用の状態ファイル
 # （~/.claude/plugins/known_marketplaces.json）にマーケットプレイスが登録されない。
-# 明示的に add して登録する（同名は置換される冪等操作。最新を clone し直すため update は不要）。
+# 明示的に add して登録する（未登録なら clone、登録済みなら何もしない）。
 claude plugin marketplace add tak848/dotfiles || echo "WARN: marketplace add failed" >&2
+# add は登録済みの marketplace を更新しない（"already on disk" で終了する）ため、
+# ~/.claude/plugins/marketplaces/tak848-plugins の clone が古いまま残り、
+# 新しく追加したプラグインが install 時に "not found in marketplace" になる。
+# 明示的に update して clone を最新にする。
+claude plugin marketplace update tak848-plugins || echo "WARN: marketplace update failed" >&2
 for plugin in aws-knowledge context7; do
     claude plugin install "${plugin}@tak848-plugins" || echo "WARN: plugin install failed: ${plugin}" >&2
 done


### PR DESCRIPTION
## Why

#843 をマージして `chezmoi update` を実行すると、context7 のインストールが失敗した。

```
✔ Marketplace 'tak848-plugins' already on disk — declared in user settings
✔ Plugin "aws-knowledge@tak848-plugins" is already installed (scope: user)
Installing plugin "context7@tak848-plugins"...
✘ Failed to install plugin "context7@tak848-plugins": Plugin "context7" not found in marketplace "tak848-plugins". Your local copy may be out of date — try `claude plugin marketplace update tak848-plugins`.
```

原因は 2 つある。

### 1. `marketplace add` は登録済みの marketplace の clone を更新しない

`claude plugin marketplace add` は登録済みの marketplace に対しては "already on disk" で終了する。スクリプトのコメントにあった「同名は置換される冪等操作。最新を clone し直すため update は不要」という前提が誤っていた。

実際に `~/.claude/plugins/marketplaces/tak848-plugins/.claude-plugin/marketplace.json` を確認したところ、プラグインは `aws-knowledge` と `gopls-lazy` の 2 件しか無く、#838 で追加した freee も入っていなかった。freee はデフォルト無効で、aws-knowledge は既にインストール済みだったため、この clone が古いまま放置されていることに今まで気づかなかった。

### 2. 失敗を WARN に丸めて exit 0 していた

これが放置の直接の原因。chezmoi は run_onchange スクリプトが非ゼロで終わると実行状態を記録しない（`TargetStateScript.Apply` が `RunScript` のエラー時に `PersistentStateSet` を呼ぶ前に return する）。つまり素直に失敗させれば、次の `chezmoi apply` で自動的に再試行される。

WARN に丸めて exit 0 すると「成功」として記録されるため、スクリプト内容が変わるまで二度と再試行されない。失敗が一度きりで消えて気づけなくなるぶん、WARN のほうが有害だった。

## What

`run_onchange_after_50-claude-plugins.sh.tmpl` を 2 点直す。

- `marketplace add` の直後に `marketplace update tak848-plugins` を追加。`add` は未登録時の clone のために残す（`update` は未登録の marketplace には使えない）
- `set -euo pipefail` を追加し、`marketplace add` / `marketplace update` / `plugin install` の `|| echo "WARN: ..."` を削除。失敗をそのまま異常終了にして chezmoi の再試行に乗せる

あわせて、誤っていたコメントを実際の挙動に合わせて書き直し、install ループに含めない理由の注記に freee を追記した（gopls-lazy と同じくデフォルト無効）。`claude` CLI が無い場合の skip（exit 0）は意図的な分岐なので維持する。

## 確認

- `claude plugin marketplace update tak848-plugins` を実行すると clone が更新され、`marketplace.json` の一覧が `aws-knowledge` / `gopls-lazy` から `aws-knowledge` / `gopls-lazy` / `freee` / `context7` に変わることを確認済み
- テンプレート記法を除去したうえで `bash -n` による構文チェックを通した
- 本 PR のマージ後、`chezmoi update` でスクリプトが再実行され（run_onchange のハッシュはスクリプト内容の変更で変わる）context7 が install されること、`/mcp` で接続と `${CONTEXT7_API_KEY}` の展開が確認できることを見る

(by Claude Code)