### PR TITLE
feat: CODEX_PROFILE を解釈する codexp を追加し gwc の Codex 起動を差し替え

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,15 @@ Homebrew
 
 これは既に有効化されている `codex@openai-codex` プラグイン（Claude Code から Codex CLI に作業を委譲する）とは別物で、両立する。
 
+### codexp（Codex を profile 付きで起動する）
+
+`dot_zsh/functions/codexp.zsh` が提供する `codexp` コマンドは、環境変数 `CODEX_PROFILE` を読んで `codex --profile <name>` に変換する薄いラッパー。Codex CLI の `--profile` は `$CODEX_HOME/<name>.config.toml` を base config の上にレイヤーする仕組みだが、Codex 自身には profile を選ぶ環境変数が無いため、repo ごとの切り替えをこの関数で補う。`CODEX_PROFILE` 未設定なら素の `codex` と完全に同じ挙動になる。
+
+- `--profile` が使えるのは runtime サブコマンド（サブコマンド無し / `exec` / `review` / `resume` / `archive` / `delete` / `unarchive` / `fork` / `mcp` / `sandbox` / `debug prompt-input`）だけで、`login` や `doctor` に付けると Codex はエラーで即終了する。そのため非対応サブコマンドを denylist で除外している
+- Codex は存在しない profile 名を黙って無視するため、`codexp` 側で profile ファイルの存在を確認して警告を出す
+- profile 定義ファイル（`$CODEX_HOME/<name>.config.toml`）は chezmoi 管理外。`dot_codex/modify_config.toml` に残る legacy な `[profiles.*]` と同名の profile 名を指定すると Codex がエラーになるため、名前を衝突させないこと
+- `gwc` の `--co` / `--ccco` は `codex` ではなく `codexp` を起動する
+
 ### 自動生成ファイル一覧
 
 | ファイル | 生成元 | 生成方法 |

--- a/dot_zsh/functions/codexp.zsh
+++ b/dot_zsh/functions/codexp.zsh
@@ -31,7 +31,7 @@ codexp() {
         update doctor debug apply a cloud exec-server features help
     )
 
-    local profile="$CODEX_PROFILE"
+    local profile="${CODEX_PROFILE:-}"
     if [ -z "$profile" ]; then
         command codex "$@"
         return

--- a/dot_zsh/functions/codexp.zsh
+++ b/dot_zsh/functions/codexp.zsh
@@ -1,0 +1,74 @@
+# codexp: CODEX_PROFILE を解釈して codex に --profile を自動付与する
+#
+# Codex CLI の --profile <name> は $CODEX_HOME/<name>.config.toml を base config
+# （$CODEX_HOME/config.toml）の上にレイヤーする。repo ごとに Codex の設定を切り替えたいが、
+# Codex 自身には profile を選ぶ環境変数が無いため、ここで補う。
+#
+#   export CODEX_PROFILE=sample
+#   codexp                  # codex --profile sample と同じ
+#   codexp exec "..."       # codex --profile sample exec "..." と同じ
+#   codexp -p other exec    # 明示指定が優先される（二重付与しない）
+#   codexp login            # profile 非対応サブコマンドには付与しない（下記参照）
+#
+# CODEX_PROFILE が未設定なら素の codex と完全に同じ挙動になる。
+#
+# 注意:
+#   - --profile が使えるのは runtime サブコマンド（サブコマンド無し / exec / review /
+#     resume / archive / delete / unarchive / fork / mcp / sandbox / debug prompt-input）
+#     だけで、login や doctor に付けると Codex はエラーで即終了する
+#   - Codex は存在しない profile 名を黙って無視する。typo に気づけないため、
+#     ここで profile ファイルの存在を確認して警告する
+#   - base config に legacy な [profiles.<name>] が残っていると、同名の --profile <name>
+#     はエラーになる。profile 名は dot_codex/modify_config.toml の [profiles.*] と
+#     衝突させないこと
+
+codexp() {
+    # --profile を付けてはいけないサブコマンド。`codex --help` のサブコマンド一覧から
+    # runtime commands を引いた差集合（a は apply の alias。exec の alias e は付与側）。
+    # debug は prompt-input だけ profile 対応だが、デバッグ用途なので debug 単位で除外する。
+    local -a no_profile_subcommands=(
+        login logout plugin mcp-server app-server remote-control app completion
+        update doctor debug apply a cloud exec-server features help
+    )
+
+    local profile="$CODEX_PROFILE"
+    if [ -z "$profile" ]; then
+        command codex "$@"
+        return
+    fi
+
+    # 明示指定があればそちらを優先する
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+        -p | --profile | --profile=*)
+            command codex "$@"
+            return
+            ;;
+        esac
+    done
+
+    # 最初の非オプショントークンをサブコマンド候補とみなす。`codex [OPTIONS] [PROMPT]` 形態では
+    # プロンプト文字列が来るが、denylist に無ければ付与する側に倒れるだけで害はない。逆に
+    # オプションの値をサブコマンドと誤認した場合も「付与しない」方向にしか外れない。
+    local subcommand=""
+    for arg in "$@"; do
+        if [[ "$arg" != -* ]]; then
+            subcommand="$arg"
+            break
+        fi
+    done
+    if [ -n "$subcommand" ] && (( ${no_profile_subcommands[(Ie)$subcommand]} )); then
+        command codex "$@"
+        return
+    fi
+
+    local profile_file="${CODEX_HOME:-$HOME/.codex}/${profile}.config.toml"
+    if [ ! -f "$profile_file" ]; then
+        echo "警告: CODEX_PROFILE='${profile}' に対応する ${profile_file} がありません。profile 無しで起動します。" >&2
+        command codex "$@"
+        return
+    fi
+
+    command codex --profile "$profile" "$@"
+}

--- a/dot_zsh/functions/git-worktree.zsh
+++ b/dot_zsh/functions/git-worktree.zsh
@@ -208,15 +208,16 @@ gwr() {
 #   gwc ENG-123 --ccs                # 作成後に claude --model sonnet を初期プロンプトで起動
 #   gwc ENG-123 --ccx                # 作成後に claudex（Claude Code のハーネス + GPT-5.6 Sol）を初期プロンプトで起動
 #   gwc ENG-123 --ccxf               # 作成後に claudexf（claudex の Codex fast/priority tier 版）を初期プロンプトで起動
-#   gwc ENG-123 --co                 # 作成後に codex を初期プロンプトで起動（GWC_CODEX_CLI_INITIAL_PROMPT）
+#   gwc ENG-123 --co                 # 作成後に codexp を初期プロンプトで起動（GWC_CODEX_CLI_INITIAL_PROMPT）
 #   gwc ENG-123 --cc "追加の指示"     # 初期プロンプト + 改行2つ + 追加プロンプトで起動（ref より後ろに置くこと）
-#   gwc ENG-123 --ccco               # cmux 限定: claude を現在ペイン、codex を右 split で同時起動
-#   gwc ENG-123 --ccco "追加の指示"   # 追加プロンプトは claude / codex 両方に渡る
+#   gwc ENG-123 --ccco               # cmux 限定: claude を現在ペイン、codexp を右 split で同時起動
+#   gwc ENG-123 --ccco "追加の指示"   # 追加プロンプトは claude / codexp 両方に渡る
 #   export GWC_COPY_FILES=".env.test,config.local.json"  # 環境変数で事前設定
 #   export GWC_PNPM_EXTRA_DIRS="apps/foo,apps/bar"  # root 以外で pnpm install するディレクトリ（worktree root からの相対パス、カンマ区切り）
 #   export GWC_LINEAR_API_KEY="lin_api_..."  # Linear モードに必要（環境変数として設定）
 #   export GWC_CLAUDE_CODE_INITIAL_PROMPT="..."  # --cc / --ccx / --ccxf で claude / claudex(f) に渡す初期プロンプト（未設定なら素の起動 or 追加プロンプトのみ）
-#   export GWC_CODEX_CLI_INITIAL_PROMPT="..."    # --co で codex に渡す初期プロンプト（同上）
+#   export GWC_CODEX_CLI_INITIAL_PROMPT="..."    # --co で codexp に渡す初期プロンプト（同上）
+#   export CODEX_PROFILE="..."       # codexp が codex --profile に渡す profile 名（codexp.zsh）
 #
 # cmux 環境（CMUX_WORKSPACE_ID あり）で Linear/PR モードを使うと、実行元の cmux
 # ワークスペース名を自動設定する（Linear: "<repo>[<ID>] <title>" / PR: "<repo>[#<番号>] <title>"）。
@@ -236,10 +237,10 @@ gwc() {
     local skip_fzf=false
     local open_with_cursor=false
     local cmux_title=""  # cmux 環境ならワークスペース名に設定する文字列（Linear/PR モードでセット）
-    local launch_agent=""  # --cc → claude / --ccx → claudex / --ccxf → claudexf / --co → codex / --ccco → claude（前面）。worktree 作成後に初期プロンプトで起動
+    local launch_agent=""  # --cc → claude / --ccx → claudex / --ccxf → claudexf / --co → codexp / --ccco → claude（前面）。worktree 作成後に初期プロンプトで起動
     local launch_model=""  # --ccf → fable / --cco → opus / --ccs → sonnet。claude 起動時だけ --model として渡す
                            # （--ccx / --ccxf は claudex(f) 側が --model を指定するため空のままにする）
-    local split_agent=""   # --ccco → codex を右 split で起動（claude は launch_agent で現在ペイン前面起動）
+    local split_agent=""   # --ccco → codexp を右 split で起動（claude は launch_agent で現在ペイン前面起動）
     local agent_extra=""   # --cc / --co / --ccco の後ろに渡された追加プロンプト
 
     # 環境変数 GWC_COPY_FILES から追加のコピー対象ファイルを取得
@@ -296,7 +297,7 @@ gwc() {
             shift
             ;;
         --cc | --co)
-            # --cc → claude / --co → codex。worktree 作成後に初期プロンプトで起動する。
+            # --cc → claude / --co → codexp。worktree 作成後に初期プロンプトで起動する。
             # 直後にオプションでないトークンがあれば追加プロンプトとして取り込む
             # （例: gwc ENG-123 --cc "追加の指示"）。ref と紛れないよう --cc/--co は ref の後ろに置くこと。
             if [ -n "$launch_agent" ] || [ -n "$split_agent" ]; then
@@ -306,7 +307,7 @@ gwc() {
             if [ "$1" = "--cc" ]; then
                 launch_agent="claude"
             else
-                launch_agent="codex"
+                launch_agent="codexp"
             fi
             shift # --cc / --co を消費
             if [ -n "$1" ] && [[ "$1" != -* ]]; then
@@ -353,7 +354,7 @@ gwc() {
             fi
             ;;
         --ccco)
-            # cmux 限定: claude を現在ペイン前面、codex を右 split で同時起動する。
+            # cmux 限定: claude を現在ペイン前面、codexp を右 split で同時起動する。
             # 末尾に非オプションのトークンがあれば両エージェント共通の追加プロンプトとして取り込む。
             if [ -n "$launch_agent" ] || [ -n "$split_agent" ]; then
                 echo "エラー: --cc / --ccf / --cco / --ccs / --ccx / --ccxf / --co / --ccco は同時に指定できません。" >&2
@@ -365,7 +366,7 @@ gwc() {
                 return 1
             fi
             launch_agent="claude"   # 現在ペインで前面起動（既存経路を再利用）
-            split_agent="codex"     # 右 split で起動
+            split_agent="codexp"    # 右 split で起動
             shift # --ccco を消費
             if [ -n "$1" ] && [[ "$1" != -* ]]; then
                 agent_extra="$1"
@@ -721,7 +722,7 @@ gwc() {
         fi
         # ★★★ ここまで ★★★
 
-        # --cc / --ccx / --ccxf / --co: worktree 内で claude / claudex / claudexf / codex を初期プロンプト付きで起動する。
+        # --cc / --ccx / --ccxf / --co: worktree 内で claude / claudex / claudexf / codexp を初期プロンプト付きで起動する。
         # プロンプトは位置引数で渡す（codex は stdin パイプ非対応のため。claude も同様に統一）。
         #   - 環境変数（GWC_CLAUDE_CODE_INITIAL_PROMPT / GWC_CODEX_CLI_INITIAL_PROMPT）と
         #     追加プロンプト（agent_extra）の両方があれば「環境変数 + 改行2つ + 追加」を送る
@@ -730,15 +731,17 @@ gwc() {
             # --cursor で original_dir に戻っている可能性があるため target_dir に入り直す
             cd "$target_dir"
 
-            # --ccco: codex を右 split で起動（claude はこの後段で現在ペイン前面起動）。
+            # --ccco: codexp を右 split で起動（claude はこの後段で現在ペイン前面起動）。
             # split は別ペイン＝別シェルのため、zsh 変数を直接渡せず cmux send でコマンドを送る。
+            # codexp は PATH 上のバイナリではなく zsh 関数だが、新ペインも interactive zsh で
+            # ~/.zshrc（→ ~/.zsh/functions/*.zsh）を読むため、送り先のシェルでも定義されている。
             # 複数行プロンプトを send にインラインで埋めると改行が Enter と解釈されコマンドが
             # 途中実行されるため、プロンプトは一時ファイルに書き split 側で cat して読み込む。
             if [ -n "$split_agent" ] && _cmux_available; then
                 if ! command -v "$split_agent" >/dev/null 2>&1; then
                     echo "警告: '$split_agent' コマンドが見つかりません。split 起動をスキップします。" >&2
                 else
-                    # codex 用プロンプト合成（既存 --co と同じ規則: GWC_CODEX_CLI_INITIAL_PROMPT + extra）
+                    # codexp 用プロンプト合成（既存 --co と同じ規則: GWC_CODEX_CLI_INITIAL_PROMPT + extra）
                     local split_base="$GWC_CODEX_CLI_INITIAL_PROMPT"
                     local split_prompt=""
                     if [ -n "$split_base" ] && [ -n "$agent_extra" ]; then


### PR DESCRIPTION
## Why

Codex CLI の `--profile <name>` は `$CODEX_HOME/<name>.config.toml` を base config の上にレイヤーする仕組みだが、Codex 自身には profile を選ぶ環境変数が無い。repo ごとに profile を切り替えたいので、`CODEX_PROFILE` を読んで `--profile` に変換する薄いラッパーを用意する。

`gwc` の `--co` / `--ccco` も、この経路を通るように起動先を差し替える。

## What

### `dot_zsh/functions/codexp.zsh`（新規）

`CODEX_PROFILE` を読んで `codex --profile <name>` を組み立てる zsh 関数。`dot_zsh/functions/*.zsh` は `dot_zshrc.tmpl` の glob ループが自動 source するため、zshrc への登録は不要。判定順序は次の通りで、`CODEX_PROFILE` 未設定なら素の `codex` と完全に同じ挙動になる。

1. `CODEX_PROFILE` が空 → 素通し
2. 引数に既に `-p` / `--profile` / `--profile=*` があれば付与しない（明示指定を優先）
3. 最初の非オプショントークンが profile 非対応サブコマンドなら付与しない
4. profile ファイルが無ければ stderr に警告して付与しない（作業は止めない）
5. それ以外は `--profile` を付与

**denylist で非対応サブコマンドを除外している理由。** `--profile` は runtime サブコマンドにしか適用できず、`login` / `doctor` / `update` などに付けると Codex が起動せずエラー終了する。

```
Error: --profile only applies to runtime commands and `codex mcp`: `codex`, `codex exec`,
`codex review`, `codex resume`, `codex archive`, `codex delete`, `codex unarchive`,
`codex fork`, `codex mcp`, `codex sandbox`, and `codex debug prompt-input`.
```

allowlist（runtime commands の列挙）にすると `codexp "プロンプト"` のように第1引数がサブコマンド名でない形を取りこぼすため、denylist を採る。denylist なら誤判定は「profile が付かない」方向にしか倒れず、エラー終了を招かない。列挙内容は `codex --help` のサブコマンド一覧から上記 runtime commands を引いた差集合。

**profile ファイルの存在確認を入れている理由。** Codex は存在しない profile 名を黙って無視して base config だけで起動するため、typo に気づけない。

### `dot_zsh/functions/git-worktree.zsh`

`--co` の `launch_agent` と `--ccco` の `split_agent` を `codex` → `codexp` に変更。初期プロンプトの分岐は `claude` / `claudex` / `claudexf` 以外を else に落とす構造なので、`GWC_CODEX_CLI_INITIAL_PROMPT` はそのまま選ばれる（ロジック変更なし、コメントのみ整合）。

`codexp` は PATH 上のバイナリではなく zsh 関数だが、`command -v` は関数を検出し、変数展開したコマンド名からも関数は呼べるため既存の起動経路はそのまま動く。`--ccco` の split 起動先も interactive zsh なので `~/.zshrc` 経由で関数が定義される。

### `CLAUDE.md`

Architecture 節に `codexp` の説明を追加。

## 検証

`zsh -n` による構文チェックに加え、`codex` のスタブを PATH に前置して引数の組み立てを確認した。

| 呼び出し | 実際に codex へ渡った引数 |
|---|---|
| `codexp` | `--profile sample` |
| `codexp "プロンプト"` | `--profile sample プロンプト` |
| `codexp exec x` | `--profile sample exec x` |
| `codexp resume --last` | `--profile sample resume --last` |
| `codexp sandbox -- ls` | `--profile sample sandbox -- ls` |
| `codexp login` | `login` |
| `codexp doctor` | `doctor` |
| `codexp completion zsh` | `completion zsh` |
| `codexp -p other exec x` | `-p other exec x` |
| `codexp --profile=other exec x` | `--profile=other exec x` |
| `codexp -m gpt-5.6-sol exec x` | `--profile sample -m gpt-5.6-sol exec x` |
| `CODEX_PROFILE=nosuch codexp exec x` | 警告を出して `exec x` |
| `CODEX_PROFILE=` `codexp exec x` | `exec x` |

実際の Codex CLI 0.146.0 でも、`codexp completion zsh` がエラーにならないこと（denylist が効いている）と、`codexp sandbox -- true` が profile 付きで起動することを確認済み。

## 既知の制約

`dot_codex/modify_config.toml` に残る legacy な `[profiles.*]`（`fast` / `xhigh` / `codex` / `codex-fast` / `codex-xhigh`）と同名の profile 名を指定すると、Codex が次のエラーを出す。今回はこれらに手を触れていないので、profile 名を衝突させない運用とする。

```
Error: --profile `<name>` cannot be used while ~/.codex/config.toml contains legacy
`profile = "<name>"` or `[profiles.<name>]` config; ...
```

これら 5 つは現状トップレベルの `profile = ` 指定も無く、どこからも使われていない。v2 レイヤーファイルへの移行または削除は別途検討する。

https://claude.ai/code/session_01DxeuSmiqrypE2AoTf15FzC