### PR TITLE
chore: CLAUDE_CODE_AUTO_COMPACT_WINDOW を 750000 に引き上げ

### DIFF
--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -28,4 +28,4 @@ export CLAUDE_CODE_AUTO_UPDATE=false
 export DISABLE_AUTOUPDATER=1
 
 # Opus の 1M context 前提の auto-compact 閾値。claudex は context の短いモデルに合わせて上書きする
-export CLAUDE_CODE_AUTO_COMPACT_WINDOW=500000
+export CLAUDE_CODE_AUTO_COMPACT_WINDOW=750000


### PR DESCRIPTION
## Why

Claude Code の性能が上がり、長い context を抱えたままでも実用に耐えるようになったため、auto-compact が発火するまでの余裕を広げたい。従来の 50 万トークンは Opus の 1M context に対して保守的すぎた。

## What

`dot_zshenv.tmpl` の `CLAUDE_CODE_AUTO_COMPACT_WINDOW` を `500000` → `750000` に変更。

`claudex`（GPT-5.6 Sol 駆動）は `CLAUDE_CODE_MAX_CONTEXT_TOKENS` で別途 context 長を指定しており、この値には依存しないため影響しない。
