### PR TITLE
fix: Grok Build CLI を mise から aqua CLI 管理へ移す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Homebrew
        ├─ npm グローバルパッケージ
        └─ aqua CLI (github backend)
             └─ mise lock で checksum 取得不可のツール
-                 └─ aws-cli, 1password/cli, zoxide
+                 └─ aws-cli, 1password/cli, zoxide, x.ai/cli/grok
 ```
 
 - **mise** (`dot_config/mise/`, `dot_local/bin/executable_mise`): ランタイム、CLI ツール、npm パッケージの統合管理。bootstrap 方式でインストール

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -106,7 +106,7 @@ tasks:
 
   #############################################################################
   # aqua checksum 生成
-  # mise lock で checksum が取得できないツール（aws-cli, 1password/cli, zoxide）用
+  # mise lock で checksum が取得できないツール（aws-cli, 1password/cli, zoxide, x.ai/cli/grok）用
   # --prune で不要なエントリを削除
   #############################################################################
   aqua:checksum:

--- a/dot_config/aquaproj-aqua/aqua-checksums.json
+++ b/dot_config/aquaproj-aqua/aqua-checksums.json
@@ -56,6 +56,26 @@
       "algorithm": "sha256"
     },
     {
+      "id": "http/storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-aarch64",
+      "checksum": "1AD7974D7386AC37C5FCFCF8EEEDF61403B6134D4F561B40C59334222F6C578B",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-x86_64",
+      "checksum": "52916267AA2F7868C23A6DD7847DFE066E39A52B8FFD216380186397EA7D0075",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-macos-aarch64",
+      "checksum": "1CAAB58EB25E1AD76B309154ACD2643A7099247555E103FE3AC63F4388099A82",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-macos-x86_64",
+      "checksum": "0302B17CF59A762977210A52DC2A25C10601EBD343E9B08C10559B423CCF7D0B",
+      "algorithm": "sha256"
+    },
+    {
       "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.542.0/registry.yaml",
       "checksum": "0FF75B25D9D7CF158DF4BDE701E55F7F0B0966F7EF4B2C329B72FA4E003E74E3",
       "algorithm": "sha256"

--- a/dot_config/aquaproj-aqua/aqua.yaml
+++ b/dot_config/aquaproj-aqua/aqua.yaml
@@ -18,3 +18,7 @@ packages:
   - name: aws/aws-cli@2.36.8
   - name: 1password/cli@v2.32.0
   - name: ajeetdsouza/zoxide@v0.10.0
+  # Grok Build CLI (xAI のターミナル向けコーディングエージェント)
+  # aqua-registry では GCS 配信の http パッケージとして定義されており repo_owner/repo_name を
+  # 持たないため、mise の aqua backend は lockfile 生成時に GitHub のタグ取得を試みて必ず失敗する
+  - name: x.ai/cli/grok@0.2.51

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -110,7 +110,7 @@ go = "1.26.5"
 "github:google-antigravity/antigravity-cli" = "1.1.6"     # agy: Gemini CLI の後継
 "aqua:openai/codex" = "0.146.0"
 "aqua:anomalyco/opencode" = "1.18.11"
-"aqua:x.ai/cli/grok" = "0.2.51" # Grok Build CLI (xAI のターミナル向けコーディングエージェント)
+# Grok Build CLI (xAI) は aqua CLI で管理（aqua-registry の http パッケージで mise lock が警告を出す）
 # Claude Code のハーネスを ChatGPT サブスクの Codex backend に向ける Anthropic 互換プロキシ。claudex から使う
 "github:raine/claude-code-proxy" = { version = "v0.1.25", matching_regex = '\.tar\.gz$' }
 "npm:ccusage" = "20.0.18"

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -1281,31 +1281,6 @@ checksum = "sha256:a526da44d5f67250598fa95e5654815e9f672b2c05d1d98c28bce0e60d3cf
 url = "https://github.com/x-motemen/ghq/releases/download/v1.10.1/ghq_windows_amd64.zip"
 url_api = "https://api.github.com/repos/x-motemen/ghq/releases/assets/394135809"
 
-[[tools."aqua:x.ai/cli/grok"]]
-version = "0.2.51"
-backend = "aqua:x.ai/cli/grok"
-
-[tools."aqua:x.ai/cli/grok"."platforms.linux-arm64"]
-url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-aarch64"
-
-[tools."aqua:x.ai/cli/grok"."platforms.linux-arm64-musl"]
-url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-aarch64"
-
-[tools."aqua:x.ai/cli/grok"."platforms.linux-x64"]
-url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-x86_64"
-
-[tools."aqua:x.ai/cli/grok"."platforms.linux-x64-musl"]
-url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-x86_64"
-
-[tools."aqua:x.ai/cli/grok"."platforms.macos-arm64"]
-url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-macos-aarch64"
-
-[tools."aqua:x.ai/cli/grok"."platforms.macos-x64"]
-url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-macos-x86_64"
-
-[tools."aqua:x.ai/cli/grok"."platforms.windows-x64"]
-url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-windows-x86_64.exe"
-
 [[tools."github:aquaproj/aqua"]]
 version = "2.62.1"
 backend = "github:aquaproj/aqua"


### PR DESCRIPTION
## Why

`mise install` のたびに以下の警告が 7 回出ていた。

```
mise WARN  [x.ai/cli/grok] failed to fetch version tags for lockfile, URL may be incorrect: aqua package x.ai/cli/grok does not have repo_owner and/or repo_name.
```

リポジトリ名が変わったわけではない。[aqua-registry の `x.ai/cli/grok`](https://github.com/aquaproj/aqua-registry/blob/main/pkgs/x.ai/cli/grok/registry.yaml) は GitHub リリースではなく Google Cloud Storage 配信の `type: http` パッケージとして定義されており、そもそも `repo_owner` / `repo_name` を持たない。一方 mise の aqua backend は lockfile を作る際に対象プラットフォームごとに `resolve_lock_info()` → `get_version_tags()` で GitHub のタグを引きに行くため（[`src/backend/aqua.rs`](https://github.com/jdx/mise/blob/main/src/backend/aqua.rs)）、必ず失敗して警告になる。`MISE_PLATFORMS` の 7 種類ぶんで 7 回、という回数とも一致する。

同じ理由で `dot_config/mise/mise.lock` の grok エントリだけ checksum を取得できておらず、URL だけが記録されていた。これは `dot_config/aquaproj-aqua/aqua.yaml` 冒頭に書かれている「mise lock で checksum が取得できないツールを管理」の条件そのものなので、aws-cli / 1password-cli / zoxide と同じ扱いに揃える。

## What

- `dot_config/mise/config.toml` から `aqua:x.ai/cli/grok` を削除し、経緯コメントを残した
- `dot_config/aquaproj-aqua/aqua.yaml` に `x.ai/cli/grok@0.2.51` を追加
- `task aqua:checksum` を実行し、darwin/linux × amd64/arm64 の 4 環境ぶんの checksum を `aqua-checksums.json` に登録（mise 管理下では取れていなかった checksum 検証が効くようになる）
- `CLAUDE.md` / `Taskfile.yaml` の「aqua CLI で管理するツール」一覧に追記

`dot_config/mise/mise.lock` からの grok エントリ削除は、リポジトリの方針どおり `lockfiles-and-checksums.yaml` ワークフローに任せる。

## 別件（この PR では触っていない）

xAI の stable channel（`https://x.ai/cli/stable`）は現在 `0.2.118` を返すが、リポジトリは追加時（#723, 2026-06-14）の `0.2.51` のまま更新されていない。`renovate.json5` には `custom.grok-build` datasource による更新ルールがあるものの機能していないように見える。同じ `overrideDatasource` 方式の `1password/cli` も `v2.32.0` 止まり（最新は `2.38.1`）なので、custom datasource のルール自体が効いていない可能性がある。切り分けは別途。
