### PR TITLE
docs: auto-compact 閾値の変更に伴い陳腐化したコメントを修正

### DIFF
--- a/dot_zsh/functions/claudex.zsh
+++ b/dot_zsh/functions/claudex.zsh
@@ -71,7 +71,7 @@ claudex() {
     # 仮定する context window を上書きする。gpt-5.6-sol の実キャップは ChatGPT/Codex backend で約372K
     # （272K↔372Kで変動）なので、既定値を372Kとする。Claude Codeはここから出力領域を予約して
     # auto-compactするため、CLAUDE_CODE_AUTO_COMPACT_WINDOWを340Kに上書きすると余裕を二重に
-    # 差し引いてしまう。グローバル設定の500Kはmodel contextの372Kにcapされるため、そのままでよい。
+    # 差し引いてしまう。グローバル設定の750Kはmodel contextの372Kにcapされるため、そのままでよい。
     # [1m] は基盤モデルが実際に1M contextをサポートする場合の指定なので使用しない。
     # statuslineも実態に合う /372k 表示になる。
     #

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -27,5 +27,6 @@ export MISE_GLOBAL_CONFIG_FILE="${XDG_CONFIG_HOME}/mise/config.toml"
 export CLAUDE_CODE_AUTO_UPDATE=false
 export DISABLE_AUTOUPDATER=1
 
-# Opus の 1M context 前提の auto-compact 閾値。claudex は context の短いモデルに合わせて上書きする
+# Opus の 1M context 前提の auto-compact 閾値。claudex はこの値を上書きせず、
+# CLAUDE_CODE_MAX_CONTEXT_TOKENS で宣言した短い model context 側に cap させる
 export CLAUDE_CODE_AUTO_COMPACT_WINDOW=750000


### PR DESCRIPTION
## Why

#851 で `CLAUDE_CODE_AUTO_COMPACT_WINDOW` を 500000 → 750000 に上げた際、値を明記していたコメントが取り残されていた（[レビュー指摘](https://github.com/tak848/dotfiles/pull/851#discussion_r3701932908)）。

また `dot_zshenv.tmpl` のコメントは「claudex は context の短いモデルに合わせて上書きする」と書いていたが、実際の `claudex` はこの環境変数を一切設定していない。`CLAUDE_CODE_MAX_CONTEXT_TOKENS` で model context を 372K と宣言し、Claude Code 側にそこへ cap させる作りになっている（`dot_zsh/functions/claudex.zsh:81`）。挙動は変わらないが、記述が `CLAUDE.md` の説明とも食い違っていた。

## What

- `dot_zsh/functions/claudex.zsh:74` の「グローバル設定の500K」→「750K」
- `dot_zshenv.tmpl:30` のコメントを実態に合わせ、claudex が上書きするのではなく model context 側に cap させている旨に書き換え

コメントのみの変更で、挙動への影響はない。
