### PR TITLE
fix: Grok Build CLI を mise の http backend に切り替える

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,6 +27,18 @@
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\nMISE_VERSION=(?<currentValue>\\S+)",
       ],
     },
+    {
+      // Renovate の mise manager は http backend を抽出対象にしていないため
+      // （サポートは core / asdf / aqua / cargo / gem / github / go / npm / pipx / spm / ubi / vfox）、
+      // [tools."http:grok"] を regex で拾って custom datasource で更新する
+      description: "Grok Build CLI: mise の http backend は mise manager が拾わないため regex で拾う",
+      customType: "regex",
+      managerFilePatterns: ["/^dot_config/mise/config\\.toml$/"],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\[tools\\."http:grok"\\]\\nversion = "(?<currentValue>[^"]+)"',
+      ],
+      versioningTemplate: "semver",
+    },
   ],
   customDatasources: {
     "1password-cli": {
@@ -51,13 +63,6 @@
       matchPackageNames: ["1password/cli"],
       overrideDatasource: "custom.1password-cli",
       overridePackageName: "1password-cli",
-      versioning: "semver",
-    },
-    {
-      description: "Grok Build CLI: use official xAI stable channel for aqua HTTP package",
-      matchPackageNames: ["x.ai/cli/grok"],
-      overrideDatasource: "custom.grok-build",
-      overridePackageName: "grok-build",
       versioning: "semver",
     },
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Homebrew
   └─ mise (統合ツール管理)
        ├─ ランタイム管理: go, node, pnpm (core backend)
        ├─ CLI ツール管理: fzf, ripgrep, starship, etc. (aqua backend)
+       ├─ 独自ホスティング配布のツール: grok (http backend)
        ├─ npm グローバルパッケージ
        └─ aqua CLI (github backend)
             └─ mise lock で checksum 取得不可のツール
@@ -192,5 +193,6 @@ dotfiles リポジトリ自体がカスタムマーケットプレイス (`tak84
 - **chezmoi ソースを編集する。** `~/.claude/CLAUDE.md` 等のターゲットではなく `dot_claude/CLAUDE.md` 等のソースを編集する。ターゲットを直接編集しても `chezmoi update` で上書きされ、PR にも含められない
 - **ツール導入手段として Homebrew を提案しない**（`packages.yaml` への追加・`brew install` を選択肢に挙げない）。mise（aqua / github / go / npm backend）または aqua CLI で完結させる
 - mise にツールを追加する際、`mise search` / `mise registry` で見つからなくても [aqua-registry](https://github.com/aquaproj/aqua-registry/tree/main/pkgs) に定義があれば `"aqua:<registry path>" = "<version>"` で追加できる（Renovate 自動更新・checksum 検証に乗る）。`http` backend で URL を手書きするのは aqua-registry にも無い最終手段のみ
+- 例外として、aqua-registry 側の定義が `type: http`（GitHub リリースではなく独自ホスティング配布）のパッケージは `aqua:` で追加しない。mise の aqua backend が lockfile 生成のたびに GitHub のタグ取得を試みて必ず失敗し警告を出すうえ、[Renovate の mise manager も aqua の http パッケージを抽出対象外にしている](https://docs.renovatebot.com/modules/manager/mise/#limitations)ため更新も効かない。この場合は mise の `http` backend で URL を直接指定する（`dot_config/mise/config.toml` の `[tools."http:grok"]` が例）
 - 環境変数（API key 等）の置き場所を勝手に特定ファイル（`.zshrc.local` 等）に指定しない。置き場所はユーザーに委ねる（エラーメッセージやコメントにも特定ファイル名を書かない）
 - `~/.codex/config.toml` 等の modify テンプレート（`dot_codex/modify_config.toml`）は、出力で再出力しないキーを `chezmoi apply` 時に削除する。ツールが書き込む既存キー（`projects` / `notice` / `hooks.state` 等）は保持ブロックに追加すること

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -110,7 +110,7 @@ go = "1.26.5"
 "github:google-antigravity/antigravity-cli" = "1.1.9"     # agy: Gemini CLI の後継
 "aqua:openai/codex" = "0.146.0"
 "aqua:anomalyco/opencode" = "1.18.11"
-"aqua:x.ai/cli/grok" = "0.2.51" # Grok Build CLI (xAI のターミナル向けコーディングエージェント)
+# Grok Build CLI (xAI) は http backend で管理（末尾の [tools."http:grok"] を参照）
 # Claude Code のハーネスを ChatGPT サブスクの Codex backend に向ける Anthropic 互換プロキシ。claudex から使う
 "github:raine/claude-code-proxy" = { version = "v0.1.30", matching_regex = '\.tar\.gz$' }
 "npm:ccusage" = "20.0.19"
@@ -118,3 +118,21 @@ go = "1.26.5"
 "npm:difit" = "5.0.8"
 "npm:@fission-ai/openspec" = "1.7.0"
 "npm:defuddle" = "0.19.2"                                  # WebFetch の代替: URL 本文をモデル要約を挟まず clean な Markdown で取得
+
+# ============================================
+# Grok Build CLI (xAI のターミナル向けコーディングエージェント)
+# ============================================
+# aqua-registry の x.ai/cli/grok は GCS 配信の http パッケージで repo_owner/repo_name を持たない。
+# mise の aqua backend は lockfile 生成のたびに GitHub のタグ取得を試みて必ず失敗し、対象
+# プラットフォームの数だけ警告を出す。Renovate の mise manager も aqua の http パッケージは
+# 抽出対象外で更新が効かない。どちらも http backend で URL を直接指定すれば解消する。
+# インラインテーブルにすると platforms を書けないため、[tools] の末尾にサブテーブルで置く。
+# renovate: datasource=custom.grok-build depName=grok-build
+[tools."http:grok"]
+version = "0.2.51"
+url = 'https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-{{ version }}-{{ os() }}-{{ arch(x64="x86_64", arm64="aarch64") }}'
+bin = "grok"
+
+# windows のアーティファクトだけ .exe が付くため個別に上書きする
+[tools."http:grok".platforms]
+windows-x64 = { url = 'https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-{{ version }}-windows-x86_64.exe' }

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -1281,31 +1281,6 @@ checksum = "sha256:a526da44d5f67250598fa95e5654815e9f672b2c05d1d98c28bce0e60d3cf
 url = "https://github.com/x-motemen/ghq/releases/download/v1.10.1/ghq_windows_amd64.zip"
 url_api = "https://api.github.com/repos/x-motemen/ghq/releases/assets/394135809"
 
-[[tools."aqua:x.ai/cli/grok"]]
-version = "0.2.51"
-backend = "aqua:x.ai/cli/grok"
-
-[tools."aqua:x.ai/cli/grok"."platforms.linux-arm64"]
-url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-aarch64"
-
-[tools."aqua:x.ai/cli/grok"."platforms.linux-arm64-musl"]
-url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-aarch64"
-
-[tools."aqua:x.ai/cli/grok"."platforms.linux-x64"]
-url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-x86_64"
-
-[tools."aqua:x.ai/cli/grok"."platforms.linux-x64-musl"]
-url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-x86_64"
-
-[tools."aqua:x.ai/cli/grok"."platforms.macos-arm64"]
-url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-macos-aarch64"
-
-[tools."aqua:x.ai/cli/grok"."platforms.macos-x64"]
-url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-macos-x86_64"
-
-[tools."aqua:x.ai/cli/grok"."platforms.windows-x64"]
-url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-windows-x86_64.exe"
-
 [[tools."github:aquaproj/aqua"]]
 version = "2.62.3"
 backend = "github:aquaproj/aqua"
@@ -1707,6 +1682,31 @@ url = "https://dl.google.com/go/go1.26.5.windows-amd64.zip"
 [[tools."go:golang.org/x/tools/gopls"]]
 version = "0.23.0"
 backend = "go:golang.org/x/tools/gopls"
+
+[[tools."http:grok"]]
+version = "0.2.51"
+backend = "http:grok"
+
+[tools."http:grok"."platforms.linux-arm64"]
+url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-aarch64"
+
+[tools."http:grok"."platforms.linux-arm64-musl"]
+url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-aarch64"
+
+[tools."http:grok"."platforms.linux-x64"]
+url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-x86_64"
+
+[tools."http:grok"."platforms.linux-x64-musl"]
+url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-x86_64"
+
+[tools."http:grok"."platforms.macos-arm64"]
+url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-macos-aarch64"
+
+[tools."http:grok"."platforms.macos-x64"]
+url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-macos-x86_64"
+
+[tools."http:grok"."platforms.windows-x64"]
+url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-windows-x86_64.exe"
 
 [[tools.node]]
 version = "24.18.1"


### PR DESCRIPTION
#852 の代替。grok を mise の外に出さず、backend の指定だけを変えて解決する。

## Why

`mise install` のたびに次の警告が出ていた。

```
mise WARN  [x.ai/cli/grok] failed to fetch version tags for lockfile, URL may be incorrect: aqua package x.ai/cli/grok does not have repo_owner and/or repo_name.
```

[aqua-registry の `x.ai/cli/grok`](https://github.com/aquaproj/aqua-registry/blob/main/pkgs/x.ai/cli/grok/registry.yaml) は GitHub リリースではなく Google Cloud Storage 配信の `type: http` パッケージで、`repo_owner` / `repo_name` を持たない。一方 mise の aqua backend は lockfile を作る際にプラットフォームごとに `resolve_lock_info()` → `get_version_tags()` で GitHub のタグを引きに行くため、必ず失敗して警告になる。`MISE_PLATFORMS` の 7 種類ぶんで 7 回、というログの回数とも一致する。

2026.8.0 でも未修正であることを、タグ `v2026.8.0` のソースと実バイナリの両方で確認した。

```
$ ~/.cache/mise/mise-2026.8.0 lock -p macos-arm64,linux-x64
mise WARN  [x.ai/cli/grok] failed to fetch version tags for lockfile, URL may be incorrect: ...
mise WARN  [x.ai/cli/grok] failed to fetch version tags for lockfile, URL may be incorrect: ...
```

調べる過程で、更新が止まっていた理由も判明した。[Renovate の mise manager は aqua の http パッケージを抽出対象外にしている](https://docs.renovatebot.com/modules/manager/mise/#limitations)。

> `aqua` packages with `http` package type ... is not supported

つまり `aqua:x.ai/cli/grok` はそもそも依存として抽出されておらず、`renovate.json5` の `overrideDatasource` ルールは一度も発火していなかった。追加時（#723, 2026-06-14）の `0.2.51` のまま止まっている（xAI の stable channel は現在 `0.2.118`）。

警告も更新不全も、原因は「aqua backend 越しに http パッケージを扱っていること」の一点にある。

## What

- `dot_config/mise/config.toml` の `aqua:x.ai/cli/grok` を `[tools."http:grok"]` に置き換え、URL をテンプレートで直接指定
- `windows-x64` だけアーティファクト名に `.exe` が付くため `[tools."http:grok".platforms]` で個別に上書き
- `.github/renovate.json5` に customManager を追加。mise manager は `http` backend も抽出対象にしていない（対応は core / asdf / aqua / cargo / gem / github / go / npm / pipx / spm / ubi / vfox）ため、`# renovate:` コメント付きのブロックを regex で拾って `custom.grok-build` datasource に繋ぐ。役目を失った `matchPackageNames: ["x.ai/cli/grok"]` の packageRule は削除
- `CLAUDE.md` に、aqua-registry 側が `type: http` の場合は `aqua:` ではなく `http:` backend を使う旨を追記

## 検証

隔離したディレクトリで実際に install・実行まで確認した。

```
$ mise lock -p linux-x64,linux-arm64,macos-x64,macos-arm64,windows-x64
✓ Updated 5 platform entries (0 skipped)      # 警告なし、5 プラットフォームとも正しい URL
$ mise install
mise http:grok@0.2.51 [1/3] download grok-0.2.51-macos-aarch64
mise http:grok@0.2.51 ✓ installed
$ mise exec -- grok --version
grok 0.2.51 (f4f85a6492e)
```

`taplo check` と customManager の regex マッチも確認済み。`mise.lock` の更新は `lockfiles-and-checksums.yaml` ワークフローに任せる。

## 補足

- aqua-registry の定義は `files:` に `grok` と `agent` の 2 つを持つが、http backend は `bin = "grok"` の 1 本のみ。`agent` という別名で呼んでいるものがあれば教えてほしい
- checksum は install したプラットフォームぶんだけ blake3 で `mise.lock` に記録される。aqua backend 時代は 1 つも記録されていなかったので後退はしない。GCS 側に checksum ファイルが公開されていない（`.sha256` / `SHASUMS` 系はいずれも 404）ため、`checksum_url` によるクロスプラットフォーム解決はできない
- 同じ `overrideDatasource` 方式を使っている `1password/cli` も `v2.32.0` 止まり（最新 `2.38.1`）。あちらは aqua CLI 管理なので別経路だが、同様に更新が効いていない可能性がある。切り分けは別途
