### PR TITLE
fix: releaseTimestamp が無い依存の age gate を外し、単独 PR に分離する

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,17 +65,28 @@
       overridePackageName: "1password-cli",
       versioning: "semver",
     },
+    // custom datasource（xAI の stable channel / 1Password の update check endpoint）は
+    // バージョン番号しか返さず releaseTimestamp を持たない。Renovate 42 以降は
+    // minimumReleaseAgeBehaviour の既定が timestamp-required で、timestamp の無い
+    // リリースを「まだ minimumReleaseAge を満たしていない」扱いにするため、
+    // internalChecksFilter=strict（既定）のもとでブランチすら作られず更新が止まる。
+    // 実際 1password/cli は Renovate 42 が出た直後の 2025-11-19 から v2.32.0 で
+    // 止まっていた。timestamp を提供しようのないデータソースなので age gate を外す。
+    //
+    // ただし age gate が効かない以上、リリース直後でも PR が立つ。group:allNonMajor の
+    // 一括 PR に混ぜると 24h 経ったものと経っていないものが同居して見分けがつかなくなるため、
+    // groupName を与えて単独 PR に分離する。
     {
-      // custom datasource（xAI の stable channel / 1Password の update check endpoint）は
-      // バージョン番号しか返さず releaseTimestamp を持たない。Renovate 42 以降は
-      // minimumReleaseAgeBehaviour の既定が timestamp-required で、timestamp の無い
-      // リリースを「まだ minimumReleaseAge を満たしていない」扱いにするため、
-      // internalChecksFilter=strict（既定）のもとでブランチすら作られず更新が止まる。
-      // 実際 1password/cli は Renovate 42 が出た直後の 2025-11-19 から v2.32.0 で
-      // 止まっていた。timestamp を提供しようのないデータソースなので age gate を外す。
-      description: "custom datasource: releaseTimestamp が無いため age gate を timestamp-optional にする",
-      matchPackageNames: ["1password/cli", "1password-cli", "grok-build"],
+      description: "1Password CLI: releaseTimestamp が無く age gate が効かないため単独 PR にする",
+      matchPackageNames: ["1password/cli", "1password-cli"],
       minimumReleaseAgeBehaviour: "timestamp-optional",
+      groupName: "1password-cli",
+    },
+    {
+      description: "Grok Build CLI: releaseTimestamp が無く age gate が効かないため単独 PR にする",
+      matchPackageNames: ["grok-build"],
+      minimumReleaseAgeBehaviour: "timestamp-optional",
+      groupName: "grok-build",
     },
     {
       // mise.lock の更新は CI 側の lockfiles-and-checksums.yaml ワークフローに任せる。

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,6 +66,18 @@
       versioning: "semver",
     },
     {
+      // custom datasource（xAI の stable channel / 1Password の update check endpoint）は
+      // バージョン番号しか返さず releaseTimestamp を持たない。Renovate 42 以降は
+      // minimumReleaseAgeBehaviour の既定が timestamp-required で、timestamp の無い
+      // リリースを「まだ minimumReleaseAge を満たしていない」扱いにするため、
+      // internalChecksFilter=strict（既定）のもとでブランチすら作られず更新が止まる。
+      // 実際 1password/cli は Renovate 42 が出た直後の 2025-11-19 から v2.32.0 で
+      // 止まっていた。timestamp を提供しようのないデータソースなので age gate を外す。
+      description: "custom datasource: releaseTimestamp が無いため age gate を timestamp-optional にする",
+      matchPackageNames: ["1password/cli", "1password-cli", "grok-build"],
+      minimumReleaseAgeBehaviour: "timestamp-optional",
+    },
+    {
       // mise.lock の更新は CI 側の lockfiles-and-checksums.yaml ワークフローに任せる。
       // Mend Cloud の allowedEnv (BUN_*, GO*, GRADLE_OPTS, RUSTC_BOOTSTRAP, PNPM_WORKERS,
       // PNPM_MAX_WORKERS) と allowedCommands (git add --all / git reset / pwd) には


### PR DESCRIPTION
## Why

#854 で `grok-build` が Renovate に検出されるようになった（[Dependency Dashboard](https://github.com/tak848/dotfiles/issues/5) に `grok-build 0.2.51` → `Updates: 0.2.118` と出ている）が、更新 PR が作られない。

原因は grok 固有ではなく、custom datasource を使っている依存すべてに効いていた。

`customDatasources` の `grok-build`（`https://x.ai/cli/stable`、plain text でバージョン番号のみ）と `1password-cli`（1Password の update check endpoint、JSON だが日時を含まない）は、どちらも **`releaseTimestamp` を返さない**。

[Renovate 42 でこの扱いが変わった](https://docs.renovatebot.com/key-concepts/minimum-release-age/#what-happens-if-the-datasource-andor-registry-does-not-provide-a-release-timestamp-when-using-minimumreleaseage)。

> Renovate 42 changed the behaviour detailed below. In Renovate 42, the absence of a release timestamp will be treated as if the release is not yet past the timestamp, which provides a safer default. Prior to Renovate 42, we would treat the dependency without a release timestamp **as if it has passed** the `minimumReleaseAge`

このリポジトリは全パッケージに `minimumReleaseAge: "24 hours"` をかけているため、timestamp の無いリリースは永久に「24 時間経っていない」判定になる。そして [`internalChecksFilter` の既定は `strict`](https://docs.renovatebot.com/configuration-options/#internalchecksfilter) なので、**ブランチすら作られない**。

> `strict`: All pending releases will be filtered. PRs will be skipped unless a non-pending version is available

時期も一致する。

| | |
|---|---|
| Renovate 42.0.0 リリース | 2025-11-06 |
| `1password/cli` の最後の更新 | 2025-11-19（v2.32.0、最新は v2.38.1） |

`aqua.yaml` の他の依存（`aws/aws-cli`、`aquaproj/aqua-registry`）は同じファイルにありながら今も更新されているので、ファイルやマネージャの問題ではない。

なお同じダッシュボードで `Updates` が出ている `aqua:DataDog/pup`（2 時間前リリース）や `jdx/mise v2026.8.1`（8 時間前）は、24 時間の age gate で正常に待機しているだけで、こちらは問題ない。

### 代替手段の検討

「Renovate が初回検知した時刻」を起点に待つオプションは存在しない。設定オプション一覧を当たった限り age 関連は `minimumReleaseAge` / `minimumReleaseAgeBehaviour` / `prNotPendingHours` / `ignoreUnstable` のみで、`prNotPendingHours` は `prCreation=not-pending` 用かつ「`minimumReleaseAge` が non-zero なら無効化される」と明記されている。Renovate が registry 側の timestamp を要求するのは supply chain 対策として意図的なもの。

データソース側から timestamp を引く道も無かった。x.ai は `https://x.ai/cli/stable` 以外に endpoint が無く（`versions.json` 等はすべて GCS の `NoSuchKey`）、GCS のオブジェクト一覧 API は匿名アクセス不可（401）。個別アーティファクトの `Last-Modified` は取れるが、custom datasource は「バージョン一覧を返す 1 つの URL」を叩く仕組みなので、バージョン発見と日時取得を組み合わせられない。

## What

`1password/cli` / `1password-cli` / `grok-build` に [`minimumReleaseAgeBehaviour: "timestamp-optional"`](https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour) を設定する。timestamp を提供しようのないデータソースなので、これらに限って gate を外す。`minimumReleaseAge: "24 hours"` の指定自体は残すので、将来これらの endpoint が日時を返すようになれば自動的に gate が効き直す。

あわせて **`groupName` を与えて単独 PR に分離する**。gate が効かない以上これらはリリース直後でも PR が立つため、`group:allNonMajor` の一括 PR に混ざると 24 時間の gate を通ったものと通っていないものが同居し、レビュー時に見分けがつかなくなる。`claude-code` / `codex` / `opencode` / `ccgate` と同じ扱いに揃える形。

## 補足

このリポジトリは automerge を設定していないため、いずれの PR も最終的なマージ判断は人が行う。今回の変更で変わるのは「これら 2 つはリリース直後に PR が立ち、待つかどうかの判断が人に移る」という点。単独 PR に分離することで、その判断が一括 PR に埋もれないようにしている。
