### PR TITLE
feat: mise.lock の欠けている checksum を CI で補完する

### DIFF
--- a/.github/scripts/fill-lockfile-checksums.sh
+++ b/.github/scripts/fill-lockfile-checksums.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# mise.lock の platform エントリのうち、url はあるが checksum が無いものを埋める。
+#
+# mise は backend が checksum を供給できる場合（aqua backend が aqua-registry から取る等）
+# に限って `mise lock` で checksum を書き込む。http backend は checksum_url が設定されて
+# いる場合しかクロスプラットフォームの checksum を解決できず、配布元が checksum ファイルを
+# 公開していないツール（x.ai の Grok Build CLI 等）は url だけが記録される。
+#
+# そのままだと install 時に整合性検証が働かないため、CI で実アーティファクトを取得して
+# sha256 を計算し、lockfile に追記する。mise は lockfile に checksum があれば install 時に
+# 検証し、不一致なら失敗する。
+#
+# 使い方: fill-lockfile-checksums.sh <lockfile> [<lockfile> ...]
+set -euo pipefail
+
+sha256_of_stdin() {
+    if command -v sha256sum &>/dev/null; then
+        sha256sum | cut -d' ' -f1
+    else
+        shasum -a 256 | cut -d' ' -f1
+    fi
+}
+
+for lockfile in "$@"; do
+    if [[ ! -f "$lockfile" ]]; then
+        echo "skip: $lockfile (not found)" >&2
+        continue
+    fi
+
+    # checksum が欠けている platform セクションを「セクション行<TAB>URL」で列挙する。
+    # mise.lock はセクション間が空行で区切られるため、空行と EOF を終端として扱う。
+    pending=$(
+        awk '
+            function flush() {
+                if (section ~ /platforms\./ && !has_checksum && url != "") {
+                    print section "\t" url
+                }
+                section = ""; has_checksum = 0; url = ""
+            }
+            /^\[/                { flush(); section = $0; next }
+            /^checksum = /       { has_checksum = 1; next }
+            /^url = /            { url = $0; sub(/^url = "/, "", url); sub(/"$/, "", url); next }
+            END                  { flush() }
+        ' "$lockfile"
+    )
+
+    if [[ -z "$pending" ]]; then
+        echo "$lockfile: すべての platform エントリに checksum がある"
+        continue
+    fi
+
+    # 同一 URL を指す platform が複数ある（linux-x64 と linux-x64-musl 等）ため、
+    # URL 単位で 1 回だけダウンロードする。
+    mapfile=$(mktemp)
+    declare -A url_to_sha=()
+    while IFS=$'\t' read -r section url; do
+        [[ -z "$section" ]] && continue
+        if [[ -z "${url_to_sha[$url]:-}" ]]; then
+            echo "checksum を計算中: $url" >&2
+            url_to_sha[$url]=$(curl -sfL --retry 3 "$url" | sha256_of_stdin)
+            if [[ -z "${url_to_sha[$url]}" ]]; then
+                echo "ERROR: ダウンロードに失敗しました: $url" >&2
+                exit 1
+            fi
+        fi
+        printf '%s\t%s\n' "$section" "${url_to_sha[$url]}" >>"$mapfile"
+    done <<<"$pending"
+
+    # TOML のキー順序に意味は無いので、セクション行の直後に checksum を挿入する。
+    tmp=$(mktemp)
+    awk -v mapfile="$mapfile" '
+        BEGIN {
+            while ((getline line < mapfile) > 0) {
+                split(line, kv, "\t")
+                sha[kv[1]] = kv[2]
+            }
+        }
+        { print }
+        /^\[/ { if ($0 in sha) print "checksum = \"sha256:" sha[$0] "\"" }
+    ' "$lockfile" >"$tmp"
+    mv "$tmp" "$lockfile"
+    rm -f "$mapfile"
+    unset url_to_sha
+
+    echo "$lockfile: $(printf '%s\n' "$pending" | wc -l | tr -d ' ') 件の checksum を追記した"
+done

--- a/.github/workflows/lockfiles-and-checksums.yaml
+++ b/.github/workflows/lockfiles-and-checksums.yaml
@@ -66,5 +66,9 @@ jobs:
           REGENERATE_CMD: |
             rm -f mise.lock && mise lock
             ( cd dot_config/mise && rm -f mise.lock && mise lock )
+            # backend が checksum を供給できないツール（http backend や、aqua-registry 側に
+            # checksum 定義が無いパッケージ）は mise lock で url しか埋まらない。
+            # lockfile を作り直した後に実アーティファクトから sha256 を計算して補う。
+            bash .github/scripts/fill-lockfile-checksums.sh mise.lock dot_config/mise/mise.lock
             ( cd dot_config/aquaproj-aqua && aqua update-checksum --prune )
         run: bash .github/scripts/commit-via-graphql.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,9 @@ dotfiles リポジトリ自体がカスタムマーケットプレイス (`tak84
 | ワークフロー | トリガー | 処理 |
 |-------------|---------|------|
 | `ci.yaml` | push | `task check` で自動生成ファイルの diff チェック |
-| `lockfiles-and-checksums.yaml` | push（`.mise.toml` / `dot_config/mise/config.toml` / `dot_config/aquaproj-aqua/aqua.yaml` 変更時、`main` / `lazy-lock-update` ブランチを除く） | `mise lock`（ルート + `dot_config/mise/`）と `aqua update-checksum --prune` を Renovate PR ブランチへ commit |
+| `lockfiles-and-checksums.yaml` | push（`.mise.toml` / `dot_config/mise/config.toml` / `dot_config/aquaproj-aqua/aqua.yaml` 変更時、`main` / `lazy-lock-update` ブランチを除く） | `mise lock`（ルート + `dot_config/mise/`）→ `fill-lockfile-checksums.sh` → `aqua update-checksum --prune` を Renovate PR ブランチへ commit |
+
+`fill-lockfile-checksums.sh` は、`mise lock` では checksum が埋まらないツールを補う。mise は backend が checksum を供給できる場合しか lockfile に書き込まないため、`http` backend のツールや aqua-registry 側に checksum 定義が無いパッケージ（`anthropics/claude-code`, `tamasfe/taplo`, `http:grok`）は url だけが残り、install 時の整合性検証が働かない。そこで実アーティファクトを取得して sha256 を計算し、lockfile に追記する。checksum のあるエントリは触らないので冪等。アーティファクトを丸ごとダウンロードする都合上、対象が増えるほど CI 時間は延びる（現状で合計 2 GB 強）。
 | `mise-bootstrap.yaml` | push（`.mise-bootstrap-version` 変更時） | `mise generate bootstrap` |
 | `lazy-lock.yaml` | nvim 設定変更 / 週次 cron | Lazy.nvim lockfile 更新（PR 作成 or Renovate PR へコミット） |
 

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -162,21 +162,27 @@ version = "2.1.221"
 backend = "aqua:anthropics/claude-code"
 
 [tools."aqua:anthropics/claude-code"."platforms.linux-arm64"]
+checksum = "sha256:d3c59d6bcc4adcf4cd85abca3bc13fa1131a34cb32f982bdf030d83a3b11e700"
 url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.221/linux-arm64/claude"
 
 [tools."aqua:anthropics/claude-code"."platforms.linux-arm64-musl"]
+checksum = "sha256:85985afd58d33578efd217788dd9e5cbbc0177ad00e638d9316c6fd89640f3ff"
 url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.221/linux-arm64-musl/claude"
 
 [tools."aqua:anthropics/claude-code"."platforms.linux-x64"]
+checksum = "sha256:60db8e88d42c24b5199c92cfd56ec88370c510c3789c6f364af748354f087ada"
 url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.221/linux-x64/claude"
 
 [tools."aqua:anthropics/claude-code"."platforms.linux-x64-musl"]
+checksum = "sha256:15b068e06eafff9b64583b46cdc065ac18b0d0d13950c2a83c6ee854f301a32f"
 url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.221/linux-x64-musl/claude"
 
 [tools."aqua:anthropics/claude-code"."platforms.macos-arm64"]
+checksum = "sha256:7a181f36ed0fc4fbac6cee4ecf2b615eff93d8b434221fff5d7c878dc5ebf380"
 url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.221/darwin-arm64/claude"
 
 [tools."aqua:anthropics/claude-code"."platforms.macos-x64"]
+checksum = "sha256:f408b9f7e46439f6e34a3687ff67433fc6bc189f40220ce4f0a1e829e58f0a52"
 url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.221/darwin-x64/claude"
 
 [[tools."aqua:arl/gitmux"]]
@@ -1091,30 +1097,37 @@ version = "0.10.0"
 backend = "aqua:tamasfe/taplo"
 
 [tools."aqua:tamasfe/taplo"."platforms.linux-arm64"]
+checksum = "sha256:033681d01eec8376c3fd38fa3703c79316f5e14bb013d859943b60a07bccdcc3"
 url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-aarch64.gz"
 url_api = "https://api.github.com/repos/tamasfe/taplo/releases/assets/257322597"
 
 [tools."aqua:tamasfe/taplo"."platforms.linux-arm64-musl"]
+checksum = "sha256:033681d01eec8376c3fd38fa3703c79316f5e14bb013d859943b60a07bccdcc3"
 url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-aarch64.gz"
 url_api = "https://api.github.com/repos/tamasfe/taplo/releases/assets/257322597"
 
 [tools."aqua:tamasfe/taplo"."platforms.linux-x64"]
+checksum = "sha256:8fe196b894ccf9072f98d4e1013a180306e17d244830b03986ee5e8eabeb6156"
 url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz"
 url_api = "https://api.github.com/repos/tamasfe/taplo/releases/assets/257322600"
 
 [tools."aqua:tamasfe/taplo"."platforms.linux-x64-musl"]
+checksum = "sha256:8fe196b894ccf9072f98d4e1013a180306e17d244830b03986ee5e8eabeb6156"
 url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz"
 url_api = "https://api.github.com/repos/tamasfe/taplo/releases/assets/257322600"
 
 [tools."aqua:tamasfe/taplo"."platforms.macos-arm64"]
+checksum = "sha256:713734314c3e71894b9e77513c5349835eefbd52908445a0d73b0c7dc469347d"
 url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-darwin-aarch64.gz"
 url_api = "https://api.github.com/repos/tamasfe/taplo/releases/assets/257323110"
 
 [tools."aqua:tamasfe/taplo"."platforms.macos-x64"]
+checksum = "sha256:898122cde3a0b1cd1cbc2d52d3624f23338218c91b5ddb71518236a4c2c10ef2"
 url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-darwin-x86_64.gz"
 url_api = "https://api.github.com/repos/tamasfe/taplo/releases/assets/257323116"
 
 [tools."aqua:tamasfe/taplo"."platforms.windows-x64"]
+checksum = "sha256:1615eed140039bd58e7089109883b1c434de5d6de8f64a993e6e8c80ca57bdf9"
 url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-windows-x86_64.zip"
 url_api = "https://api.github.com/repos/tamasfe/taplo/releases/assets/257323062"
 
@@ -1688,24 +1701,31 @@ version = "0.2.51"
 backend = "http:grok"
 
 [tools."http:grok"."platforms.linux-arm64"]
+checksum = "sha256:1ad7974d7386ac37c5fcfcf8eeedf61403b6134d4f561b40c59334222f6c578b"
 url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-aarch64"
 
 [tools."http:grok"."platforms.linux-arm64-musl"]
+checksum = "sha256:1ad7974d7386ac37c5fcfcf8eeedf61403b6134d4f561b40c59334222f6c578b"
 url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-aarch64"
 
 [tools."http:grok"."platforms.linux-x64"]
+checksum = "sha256:52916267aa2f7868c23a6dd7847dfe066e39a52b8ffd216380186397ea7d0075"
 url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-x86_64"
 
 [tools."http:grok"."platforms.linux-x64-musl"]
+checksum = "sha256:52916267aa2f7868c23a6dd7847dfe066e39a52b8ffd216380186397ea7d0075"
 url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-linux-x86_64"
 
 [tools."http:grok"."platforms.macos-arm64"]
+checksum = "sha256:1caab58eb25e1ad76b309154acd2643a7099247555e103fe3ac63f4388099a82"
 url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-macos-aarch64"
 
 [tools."http:grok"."platforms.macos-x64"]
+checksum = "sha256:0302b17cf59a762977210a52dc2a25c10601ebd343e9b08c10559b423ccf7d0b"
 url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-macos-x86_64"
 
 [tools."http:grok"."platforms.windows-x64"]
+checksum = "sha256:3d7fd4a04ef7f6e88b0ffb3ccee21e367ff7424e4a8877ee6e9e069ef8dc5e66"
 url = "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-0.2.51-windows-x86_64.exe"
 
 [[tools.node]]


### PR DESCRIPTION
## Why

`dot_config/mise/mise.lock` を見ると、一部のツールが `url` だけで `checksum` を持っていない。install 時の整合性検証が働いていない状態だった。

```toml
[tools."aqua:jqlang/jq"."platforms.macos-arm64"]
checksum = "sha256:a9fe3ea2..."          # ほとんどのツールはある

[tools."http:grok"."platforms.linux-x64"]
url = "https://storage.googleapis.com/..."   # url のみ
```

mise は backend が checksum を供給できる場合しか lockfile に書き込まない。該当したのは 3 ツール。

| ツール | backend | checksum が無い理由 |
|---|---|---|
| `http:grok` | http | 配布元（GCS）が checksum ファイルを公開しておらず `checksum_url` を設定できない |
| `aqua:anthropics/claude-code` | aqua | aqua-registry 側の定義に checksum ブロックが無い |
| `aqua:tamasfe/taplo` | aqua | 同上 |

`mise lock` は他プラットフォームのアーティファクトをダウンロードしない設計なので、実アーティファクトを取得しない限り埋まらない。ルートの `mise.lock` には欠けが無い。

## What

`.github/scripts/fill-lockfile-checksums.sh` を追加し、`lockfiles-and-checksums.yaml` の `REGENERATE_CMD` で `mise lock` の後に実行する。

- `url` はあるが `checksum` が無い platform エントリを列挙し、実アーティファクトを取得して sha256 を計算、lockfile に追記する
- checksum のあるエントリには触らないので冪等（2 回目は「すべての platform エントリに checksum がある」で終わる）
- 同じ URL を指すエントリ（`linux-x64` と `linux-x64-musl` 等）は 1 回だけダウンロードする
- `sha256sum` / `shasum` の両方に対応（CI は ubuntu、手元は macOS）

Taskfile には入れていない。`mise.lock` の更新はワークフローに任せる方針であることと、手元で `task` を叩くたびに 2 GB 強のダウンロードが走るのを避けるため。

## 検証

**1. 書き込んだ値が mise の検証対象と一致すること**（install が通る）

http backend（raw バイナリ）と aqua backend（`.gz` アーカイブ）の 2 パターンで確認した。checksum が無いときは `generate checksum`、あるときは `checksum` のステップに変わる。

```
mise http:grok@0.2.51 [3/3] checksum grok-0.2.51-macos-aarch64
mise http:grok@0.2.51 ✓ installed

mise aqua:tamasfe/taplo@0.10.0 [1/3] checksum taplo-darwin-aarch64.gz
mise aqua:tamasfe/taplo@0.10.0 ✓ installed
```

**2. 改竄検知が実際に効くこと**

lockfile の checksum をわざと壊すと install が失敗する。

```
mise ERROR Failed to install http:grok@0.2.51: Checksum mismatch for file ...
Expected: sha256:deadbeefdeadbeef...
Actual:   sha256:1caab58eb25e1ad7...
```

**3. 計算値が独立した手段と一致すること**

grok の 4 環境ぶんの値が、`aqua update-checksum` が算出した値と完全一致した（`1ad7974d…` / `52916267…` / `1caab58e…` / `0302b17c…`）。

## CI への影響

checksum は実アーティファクトを丸ごと取得しないと計算できないため、ワークフローの実行時間が延びる。

| ツール | URL 数 | ダウンロード量 |
|---|---|---|
| `aqua:anthropics/claude-code` | 6 | 約 1.6 GB |
| `http:grok` | 5 | 約 600 MB |
| `aqua:tamasfe/taplo` | 5 | 約 20 MB |

claude-code は `minimumReleaseAge: 0` で独立 PR が立つため、ほぼ毎日この 1.6 GB が走る。対象を絞る場合はスクリプトに除外リストを足す形になるが、今回は 3 つとも対象にしている。
