### PR TITLE
feat: Azure CLI を mise の github backend で追加する

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,6 +39,18 @@
       ],
       versioningTemplate: "semver",
     },
+    {
+      // Azure CLI の tarball は Python を同梱しないため run_onchange スクリプトで uv python install
+      // する。mise manager が見るのは config.toml のツール定義だけなので、スクリプト側は regex で追う。
+      description: "Azure CLI が使う Python: run_onchange スクリプトのバージョンを追う",
+      customType: "regex",
+      managerFilePatterns: [
+        "/^run_onchange_after_15-azure-cli-python\\.sh\\.tmpl$/",
+      ],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\nAZURE_CLI_PYTHON_VERSION="(?<currentValue>[^"]+)"',
+      ],
+    },
   ],
   customDatasources: {
     "1password-cli": {
@@ -133,6 +145,17 @@
       matchPackageNames: ["Azure/azure-cli"],
       matchManagers: ["mise"],
       extractVersion: "^azure-cli-(?<version>.+)$",
+    },
+    {
+      // uv は Python のダウンロード metadata をバイナリに焼き込んでいるため、CPython のパッチが
+      // 出ても uv 自体が更新されるまでは `uv python install <patch>` が
+      // `No download found for request` で失敗する。実際 CPython 3.14.7 は 2026-08-05 12:40 UTC
+      // リリース、python-build-standalone のビルドは同日 17:58 UTC、uv 0.12.2 は同日 19:22 UTC で、
+      // astral 側の追随自体は速い。待ちが生じるのはこのリポジトリで uv の更新 PR がマージされるまで。
+      // その猶予として age gate を長めに取る。
+      description: "Azure CLI が使う Python: uv 側の追随を待つため age gate を長めにする",
+      matchDatasources: ["python-version"],
+      minimumReleaseAge: "7 days",
     },
     {
       description: "Use node versioning for Node.js (LTS only)",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -126,6 +126,15 @@
       minimumReleaseAge: "0 hours",
     },
     {
+      // config.toml 側は version_prefix = "azure-cli-" を使って version に素の semver を書いている。
+      // datasource が返すのはタグ名（azure-cli-2.89.0）なので、ここで version 部分だけを取り出して
+      // currentValue と比較・書き戻しできるようにする。codex の rust-v prefix と同じ扱い。
+      description: "Azure CLI: GitHub のタグが azure-cli-<version> 形式なので version 部分だけを抽出する",
+      matchPackageNames: ["Azure/azure-cli"],
+      matchManagers: ["mise"],
+      extractVersion: "^azure-cli-(?<version>.+)$",
+    },
+    {
       description: "Use node versioning for Node.js (LTS only)",
       matchPackageNames: ["nodejs/node"],
       versioning: "node",

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -20,9 +20,10 @@ NPM_CONFIG_TRUST_POLICY_EXCLUDE = "tinyexec@1.2.2"
 # Azure CLI の tarball は Python を同梱しておらず、libexec/lib/python3.14/site-packages と
 # bash ランチャーだけが入っている。ランチャーは Homebrew Cask 配下に置かれていない場合、
 # AZ_PYTHON が指す Python 3.14 で `python -sm azure.cli` を実行する作りで、未設定なら即エラー終了する。
-# mise の python backend で入れると PATH に python / python3 が生えて誰でも使えてしまうため、
-# PATH に出てこない uv 管理の Python を指す。未導入のマシンでは `uv python install 3.14` で用意する。
-AZ_PYTHON = '{{env.HOME}}/.local/share/uv/python/cpython-3.14-macos-{{ arch(x64="x86_64", arm64="aarch64") }}-none/bin/python3.14'
+# mise の python backend で入れると PATH に python / python3 が生えて誰でも使えてしまうため使わない。
+# uv も既定では実行ファイルを ~/.local/bin（uv python dir --bin）に置いて PATH に生やすので、
+# azure-cli 専用のディレクトリに閉じ込める。実体を入れるのは tools 側の postinstall。
+AZ_PYTHON = '{{ env.XDG_DATA_HOME | default(value=env.HOME ~ "/.local/share") }}/azure-cli/python/python3.14'
 
 [tools]
 # ============================================
@@ -83,8 +84,10 @@ go = "1.26.5"
 # matching_regex は x86_64 マシンで -x64.msi / -x64.zip を掴まないための保険。
 # tag が azure-cli-<version> 形式なので version_prefix で補い、version 自体は素の semver にする
 # （Renovate に extractVersion で追わせるため。renovate.json5 の packageRules を参照）。
-# 実行には AZ_PYTHON が必要（[env] を参照）。
-"github:Azure/azure-cli" = { version = "2.89.0", version_prefix = "azure-cli-", os = ["macos"], matching_regex = "macos" }
+# 実行に必要な Python 3.14 は postinstall で入れる。UV_PYTHON_BIN_DIR を指定しないと uv が
+# ~/.local/bin に python3.14 を置いて PATH に生えるため、[env] の AZ_PYTHON と同じ
+# azure-cli 専用ディレクトリに向ける（postinstall には [env] が渡らないのでシェル側で XDG を解決する）。
+"github:Azure/azure-cli" = { version = "2.89.0", version_prefix = "azure-cli-", os = ["macos"], matching_regex = "macos", depends = ["aqua:astral-sh/uv"], postinstall = 'UV_PYTHON_BIN_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/azure-cli/python" uv python install 3.14' }
 
 # 開発ツール
 "aqua:bufbuild/buf" = "1.72.0"

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -84,10 +84,9 @@ go = "1.26.5"
 # matching_regex は x86_64 マシンで -x64.msi / -x64.zip を掴まないための保険。
 # tag が azure-cli-<version> 形式なので version_prefix で補い、version 自体は素の semver にする
 # （Renovate に extractVersion で追わせるため。renovate.json5 の packageRules を参照）。
-# 実行に必要な Python 3.14 は postinstall で入れる。UV_PYTHON_BIN_DIR を指定しないと uv が
-# ~/.local/bin に python3.14 を置いて PATH に生えるため、[env] の AZ_PYTHON と同じ
-# azure-cli 専用ディレクトリに向ける（postinstall には [env] が渡らないのでシェル側で XDG を解決する）。
-"github:Azure/azure-cli" = { version = "2.89.0", version_prefix = "azure-cli-", os = ["macos"], matching_regex = "macos", depends = ["aqua:astral-sh/uv"], postinstall = 'UV_PYTHON_BIN_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/azure-cli/python" uv python install 3.14' }
+# 実行に必要な Python 3.14 は run_onchange_after_15-azure-cli-python.sh.tmpl が入れる。
+# mise の postinstall はシステムの PATH で走り mise 管理の uv が使えないため、そちらには置けない。
+"github:Azure/azure-cli" = { version = "2.89.0", version_prefix = "azure-cli-", os = ["macos"], matching_regex = "macos" }
 
 # 開発ツール
 "aqua:bufbuild/buf" = "1.72.0"

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -17,6 +17,13 @@ locked = false
 # 参考: https://github.com/tak848/dotfiles/actions/runs/26555130050
 NPM_CONFIG_TRUST_POLICY_EXCLUDE = "tinyexec@1.2.2"
 
+# Azure CLI の tarball は Python を同梱しておらず、libexec/lib/python3.14/site-packages と
+# bash ランチャーだけが入っている。ランチャーは Homebrew Cask 配下に置かれていない場合、
+# AZ_PYTHON が指す Python 3.14 で `python -sm azure.cli` を実行する作りで、未設定なら即エラー終了する。
+# mise の python backend で入れると PATH に python / python3 が生えて誰でも使えてしまうため、
+# PATH に出てこない uv 管理の Python を指す。未導入のマシンでは `uv python install 3.14` で用意する。
+AZ_PYTHON = '{{env.HOME}}/.local/share/uv/python/cpython-3.14-macos-{{ arch(x64="x86_64", arm64="aarch64") }}-none/bin/python3.14'
+
 [tools]
 # ============================================
 # ランタイム（core backend）
@@ -71,6 +78,13 @@ go = "1.26.5"
 # クラウド・インフラ（aws-cli は aqua CLI で管理）
 "aqua:kubernetes/kubectl" = "1.35.0"
 "aqua:cloudflare/cloudflared" = "2026.7.3"
+# Azure CLI。aqua-registry に Azure/azure-cli の定義が無いため github backend で入れる。
+# リリースアセットは macOS 用 tarball と Windows 用 msi/zip だけで Linux 向けが無いので os で絞る。
+# matching_regex は x86_64 マシンで -x64.msi / -x64.zip を掴まないための保険。
+# tag が azure-cli-<version> 形式なので version_prefix で補い、version 自体は素の semver にする
+# （Renovate に extractVersion で追わせるため。renovate.json5 の packageRules を参照）。
+# 実行には AZ_PYTHON が必要（[env] を参照）。
+"github:Azure/azure-cli" = { version = "2.89.0", version_prefix = "azure-cli-", os = ["macos"], matching_regex = "macos" }
 
 # 開発ツール
 "aqua:bufbuild/buf" = "1.72.0"

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -1294,6 +1294,24 @@ checksum = "sha256:a526da44d5f67250598fa95e5654815e9f672b2c05d1d98c28bce0e60d3cf
 url = "https://github.com/x-motemen/ghq/releases/download/v1.10.1/ghq_windows_amd64.zip"
 url_api = "https://api.github.com/repos/x-motemen/ghq/releases/assets/394135809"
 
+[[tools."github:Azure/azure-cli"]]
+version = "2.89.0"
+backend = "github:Azure/azure-cli"
+
+[tools."github:Azure/azure-cli".options]
+matching_regex = "macos"
+version_prefix = "azure-cli-"
+
+[tools."github:Azure/azure-cli"."platforms.macos-arm64"]
+checksum = "sha256:ac5e8ce16b2355a55a3bea20afee9d3d2dbc1289a18e8aa3625d0b62910124ba"
+url = "https://github.com/Azure/azure-cli/releases/download/azure-cli-2.89.0/azure-cli-2.89.0-macos-arm64.tar.gz"
+url_api = "https://api.github.com/repos/Azure/azure-cli/releases/assets/500703301"
+
+[tools."github:Azure/azure-cli"."platforms.macos-x64"]
+checksum = "sha256:9b94be70fe95b547b1208c07f3018e8880a5676aaff3335005ab445ab5044792"
+url = "https://github.com/Azure/azure-cli/releases/download/azure-cli-2.89.0/azure-cli-2.89.0-macos-x86_64.tar.gz"
+url_api = "https://api.github.com/repos/Azure/azure-cli/releases/assets/500703321"
+
 [[tools."github:aquaproj/aqua"]]
 version = "2.62.3"
 backend = "github:aquaproj/aqua"

--- a/run_onchange_after_15-azure-cli-python.sh.tmpl
+++ b/run_onchange_after_15-azure-cli-python.sh.tmpl
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+# Azure CLI が実行に使う Python を用意する。
+#
+# Azure CLI の tarball（dot_config/mise/config.toml の github:Azure/azure-cli）は Python を
+# 同梱しておらず、bash ランチャーが AZ_PYTHON の指す Python 3.14 で azure.cli を起動する。
+# mise の python backend で入れると PATH に python / python3 が生えて Azure CLI 以外からも
+# 使えてしまうため使わない。uv も既定では実行ファイルを ~/.local/bin（uv python dir --bin）に
+# 置いて PATH に生やすので、UV_PYTHON_BIN_DIR で azure-cli 専用ディレクトリに閉じ込める。
+# 置き場所は config.toml の [env] AZ_PYTHON と一致させること。
+#
+# mise の postinstall ではなくここに置いている理由は、postinstall がシステムの PATH で実行され、
+# mise 管理の uv を解決できないため。実際 postinstall 内の uv は Homebrew の古い版が使われ、
+# 新しい CPython パッチを知らず `No download found for request` で失敗した。
+# path-setup.tmpl は mise shims を Homebrew より前に置くので、ここでは mise 管理の uv が使われる。
+
+{{ template "path-setup.tmpl" . }}
+
+{{- if eq .chezmoi.os "darwin" }}
+# uv は Python のダウンロード metadata をバイナリに焼き込んでいるため、CPython のパッチが出ても
+# uv 自体が更新されるまでは入れられない。Renovate 側で age gate を長めに取って追随を待つ
+# （.github/renovate.json5 の packageRules を参照）。
+# renovate: datasource=python-version depName=python
+AZURE_CLI_PYTHON_VERSION="3.14.6"
+
+if command -v uv &> /dev/null; then
+    export UV_PYTHON_BIN_DIR="${XDG_DATA_HOME}/azure-cli/python"
+    echo "Azure CLI 用の Python ${AZURE_CLI_PYTHON_VERSION} を用意中..."
+    uv python install "${AZURE_CLI_PYTHON_VERSION}"
+fi
+{{- end }}


### PR DESCRIPTION
## Why

Azure CLI を mise で管理したい。導入手段として aqua と github backend を調べた結果、aqua は使えず github backend なら入ることが分かったため、そちらで追加する。

**aqua は不可。** aqua-registry の `pkgs/Azure/` にあるのは aks-engine / aztfexport / azure-dev / bicep / draft / kubelogin / mapotf だけで、`Azure/azure-cli` の定義が無い（`registry.yaml` にも該当なし）。

**github backend は可能だが条件付き。** [Azure/azure-cli のリリース](https://github.com/Azure/azure-cli/releases)は 2.85.0 から macOS 用 tarball を配布し始めていて、2.89.0 には `azure-cli-2.89.0-macos-arm64.tar.gz` / `-macos-x86_64.tar.gz` がある。ただし次の制約がある。

- **Linux 向けアセットが無い。** 配布物は macOS の tar.gz 2種と Windows の msi/zip のみ
- **Python を同梱していない。** tarball の中身は `bin/az`（bash ランチャー）と `libexec/lib/python3.14/site-packages` だけで、ランチャーは Homebrew Cask 配下に置かれていない場合 `AZ_PYTHON` が指す Python 3.14 で `python -sm azure.cli` を実行する。未設定なら `Error: AZ_PYTHON not set.` で即終了する
- **公式にはまだ preview。** [Install Azure CLI on macOS - Preview](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-macos-preview?view=azure-cli-latest) の通り、Homebrew Cask 方式も tarball 方式も preview 段階。なおドキュメントは前提を Python 3.13 と書いているが、2.89.0 実物のランチャーは 3.14 を要求していて記述が追随していない

## What

Azure CLI 本体を `dot_config/mise/config.toml` に追加し、実行に必要な Python 3.14 の用意を `run_onchange` スクリプトに置いた。どちらも Renovate で追随する。

### tools（config.toml）

```toml
"github:Azure/azure-cli" = { version = "2.89.0", version_prefix = "azure-cli-", os = ["macos"], matching_regex = "macos" }
```

- `os = ["macos"]`: Linux 向けアセットが無いため対象を絞る
- `matching_regex = "macos"`: x86_64 マシンで `-x64.msi` / `-x64.zip` を掴まないための保険
- `version_prefix = "azure-cli-"`: tag が `azure-cli-<version>` 形式なので prefix を設定から分離し、version 自体は素の semver で書く

### env（config.toml）

```toml
AZ_PYTHON = '{{ env.XDG_DATA_HOME | default(value=env.HOME ~ "/.local/share") }}/azure-cli/python/python3.14'
```

Python の調達に mise の python backend は使っていない。PATH に `python` / `python3` が生えて Azure CLI 以外からも自由に使えるようになるため。ただし uv も既定では Python 実行ファイルを `~/.local/bin`（`uv python dir --bin`）に置いて PATH に生やす（[uv storage reference](https://docs.astral.sh/uv/reference/storage/)）。そのため `UV_PYTHON_BIN_DIR` で azure-cli 専用ディレクトリを指定して閉じ込め、`AZ_PYTHON` は同じ場所を指す。

### Python の用意（run_onchange_after_15-azure-cli-python.sh.tmpl）

```bash
# renovate: datasource=python-version depName=python
AZURE_CLI_PYTHON_VERSION="3.14.6"

if command -v uv &> /dev/null; then
    export UV_PYTHON_BIN_DIR="${XDG_DATA_HOME}/azure-cli/python"
    uv python install "${AZURE_CLI_PYTHON_VERSION}"
fi
```

**mise の `postinstall` ではなく run_onchange に置いた理由**は、postinstall がシステムの PATH で実行され mise 管理のツールを解決できないため。検証では postinstall 内の `command -v uv` が `/opt/homebrew/bin/uv`（0.10.6、2026-02-24 ビルド）を返し、6月リリースの CPython 3.14.6 を知らず `No download found for request` で失敗した。uv 0.12.1 を install 済みの状態でも変わらず、`mise which uv` も postinstall 内からは「not a mise bin」で失敗する。uv が入っていないマシンでは `command not found` になる。

`path-setup.tmpl` は mise shims を Homebrew より前に置く（「これが無いと run_onchange 内で /opt/homebrew/bin の野良ツールが mise 版を追い越して呼ばれる」というコメント付き）ので、run_onchange なら mise 管理の uv が使われる。postinstall と違い、バージョンを上げればスクリプトのハッシュが変わって再実行されるため、更新が実際に適用される点も利点。

### Renovate

- azure-cli 本体: tag が `azure-cli-<version>` 形式なので `extractVersion` で version 部分を抽出（codex の `rust-v` prefix と同じ扱い）
- Python: `python-version` datasource を custom regex manager で追う。**age gate を 7 days** に設定した。uv は Python のダウンロード metadata をバイナリに焼き込んでいるため、CPython のパッチが出ても uv 自体が更新されるまでは入れられない。CPython 3.14.7 の例では python.org リリース 8/5 12:40 UTC → python-build-standalone 同日 17:58 UTC → uv 0.12.2 同日 19:22 UTC と astral 側の追随は速く、実際の待ちはこのリポジトリで uv 更新 PR がマージされるまでなので、その猶予として設定している

## 動作確認

隔離環境（`MISE_DATA_DIR` / `MISE_CACHE_DIR` を作業ディレクトリに向け、global config を除外し、`XDG_DATA_HOME` も作業ディレクトリに差し替え）で、この PR の `config.toml` をそのまま使って確認した。

- `mise install` が成功し、checksum に加えて **GitHub artifact attestations と SLSA provenance の検証も通る**
- `mise env` で `AZ_PYTHON` が `${XDG_DATA_HOME}/azure-cli/python/python3.14` に展開される。`XDG_DATA_HOME` 未設定時は `~/.local/share/...` にフォールバックすることも確認済み
- mise 管理の uv 0.12.1 で `UV_PYTHON_BIN_DIR` 指定の `uv python install 3.14.6` が成功し、その場所に `python3.14` が作られる
- `mise exec -- az version` が `azure-cli 2.89.0` を出力する
- `~/.local/bin` には何も作られない
- run_onchange スクリプトは `chezmoi execute-template` で展開でき、展開結果の `bash -n` も通る

未確認:

- `os = ["macos"]` が実際に Linux でインストールをスキップする挙動（macOS 上のため検証できない。mise のドキュメント記載に基づく）
- run_onchange スクリプトの Linux 側分岐（`{{ if eq .chezmoi.os "darwin" }}` でスキップされる想定。CI の `chezmoi --dry-run apply` で検証される）

## 備考

`mise.lock` はこのブランチへの push で `lockfiles-and-checksums.yaml` が更新するため、ローカルでは触っていない。
