### PR TITLE
fix: difit を mise から削除して npm backend の trust policy 失敗を解消する

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -131,7 +131,6 @@ go = "1.26.5"
 "github:raine/claude-code-proxy" = { version = "v0.1.30", matching_regex = '\.tar\.gz$' }
 "npm:ccusage" = "20.0.19"
 "npm:@typescript/native-preview" = "7.0.0-dev.20260707.2"
-"npm:difit" = "5.0.8"
 "npm:@fission-ai/openspec" = "1.7.0"
 "npm:defuddle" = "0.19.2"                                  # WebFetch の代替: URL 本文をモデル要約を挟まず clean な Markdown で取得
 

--- a/dot_config/mise/mise.lock
+++ b/dot_config/mise/mise.lock
@@ -1794,10 +1794,6 @@ backend = "npm:ccusage"
 version = "0.19.2"
 backend = "npm:defuddle"
 
-[[tools."npm:difit"]]
-version = "5.0.8"
-backend = "npm:difit"
-
 [[tools.pnpm]]
 version = "11.18.0"
 backend = "aqua:pnpm/pnpm"


### PR DESCRIPTION
## Why

Renovate PR (#855, #871, #872, #873) の CI が軒並み落ちていた。原因は difit ではなくその推移的依存 `cytoscape` の publish 方法の変化。

```
Failed to install npm:difit@5.0.8: aube install failed: failed to resolve dependencies
  caused by: trust downgrade for cytoscape@3.34.1 (trustPolicy=no-downgrade):
  earlier published version 3.33.4 had trusted publisher but this version has no trust evidence
```

npm registry を確認したところ、cytoscape の publish 経路が 3.34.1 で変わっている。

| version | published | publisher | provenance |
|---|---|---|---|
| 3.33.4 | 2026-05-19 | GitHub Actions (OIDC trusted publisher) | SLSA v1 attestation あり |
| 3.34.0 | 2026-06-02 | GitHub Actions (OIDC trusted publisher) | SLSA v1 attestation あり |
| 3.34.1 | 2026-08-11 | `maxkfranz`（メンテナ本人の手動 publish） | attestation なし |

`maxkfranz` は cytoscape.js のメインメンテナで、GitHub 上にも同時刻（2026-08-11T15:40:43Z）に v3.34.1 タグとリリースが存在する。改竄ではなく、リリース作業がトラステッドワークフロー外で行われた結果と見られる。ただし mise (aube) の `trustPolicy=no-downgrade` から見れば「以前は provenance があったのに今は無い」= trust downgrade なので install が拒否される。difit の依存範囲は `mermaid ^11.13.0` 経由で cytoscape が入り、範囲解決の結果 latest の 3.34.1 が選ばれるため、difit を入れている限り必ず落ちる。

## What

- `dot_config/mise/config.toml` から `"npm:difit"` を削除
- `dot_config/mise/mise.lock` の該当ブロックを削除

difit はもう使っていないため、`trust_policy_excludes = ["cytoscape@3.34.1"]` で bypass するのではなく削除する方針を採った。bypass は cytoscape が provenance 付きの publish に戻っても除外設定が残り続け、次に本当に怪しい downgrade が起きたときに気づけなくなる。

### 残る npm backend ツールの状況

同じ事故は他の `npm:` ツールでも起こりうるため、現状を確認した。

| tool | publisher | provenance | no-downgrade のリスク |
|---|---|---|---|
| `npm:ccusage` | GitHub Actions (OIDC) | あり | provenance が外れた瞬間に落ちる |
| `npm:@fission-ai/openspec` | GitHub Actions (OIDC) | あり | 同上 |
| `npm:defuddle` | `kepano`（手動） | なし | 元から無いので downgrade は発生しない |
| `npm:@typescript/native-preview` | `microsoft1es`（手動） | なし | 同上 |

いずれも現時点では通る。ただし ccusage / openspec は「今 provenance がある」側なので、上流が publish 経路を変えた瞬間に今回と同じ形で CI が止まる。

## Testing

- 未実施（この PR の CI で検証する）。ローカルでの `mise install` はグローバル環境を触るため実行していない
- 失敗ログの一次確認: [run 31755057173 (#872)](https://github.com/tak848/dotfiles/actions/runs/31755057173/job/94628939040), [run 31768967983 (#855)](https://github.com/tak848/dotfiles/actions/runs/31768967983/job/94670671223)
- cytoscape の publisher / attestation は npm registry API (`registry.npmjs.org/cytoscape/<version>`) と GitHub Releases API で直接確認した

(by Claude Code)
